### PR TITLE
doc: mention rtk is Rust Token Killer

### DIFF
--- a/rules/RTK.md
+++ b/rules/RTK.md
@@ -1,3 +1,3 @@
-Always prefix shell commands with `rtk` — hard requirement, not optional. RTK calls binaries directly and bypasses aliases.
+Always prefix shell commands with `rtk` (where rtk stands for **Rust Token Killer**: <https://github.com/rtk-ai/rtk>) — hard requirement, not optional. RTK calls binaries directly and bypasses aliases.
 
 RTK does not support `-C <dir>` — use `command git -C <dir>` or absolute paths for submodule git operations.


### PR DESCRIPTION
Make sure proper rtk is used. As rust doken killer warns in its repo, "There are TWO different projects named "rtk":

    ✅ This project (Rust Token Killer) - LLM token optimizer
        Repos: rtk-ai/rtk
        Purpose: Reduce Claude Code token consumption

    ❌ reachingforthejack/rtk - Rust Type Kit (DIFFERENT PROJECT)
        Purpose: Query Rust codebase and generate types
        DO NOT install this one if you want token optimization"