### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything
+* @N4M3Z


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` assigning @N4M3Z as default owner for all files
- Future PRs will automatically request review from the code owner

## Next step

Enable `require_code_owner_review` on the `main` ruleset so CODEOWNERS approval is enforced.