### PR TITLE
feat: add VersionControl skill with GitHub and GitLab governance

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -7,6 +7,7 @@ skills:
         BuildAgent:
         BuildModule:
         BuildHook:
+        VersionControl:
         MarkdownLint:
         MarkdownSchema:
         SettingsMaintenance:
@@ -19,6 +20,7 @@ skills:
         BuildAgent:
         BuildModule:
         BuildHook:
+        VersionControl:
         MarkdownLint:
         MarkdownSchema:
         SettingsMaintenance:
@@ -31,6 +33,7 @@ skills:
         BuildAgent:
         BuildModule:
         BuildHook:
+        VersionControl:
         MarkdownLint:
         MarkdownSchema:
         SettingsMaintenance:
@@ -43,6 +46,7 @@ skills:
         BuildAgent:
         BuildModule:
         BuildHook:
+        VersionControl:
         MarkdownLint:
         MarkdownSchema:
         SettingsMaintenance:

--- a/skills/VersionControl/GitHub.md
+++ b/skills/VersionControl/GitHub.md
@@ -1,0 +1,110 @@
+## GitHub Repo Governance
+
+Branch protection and code ownership via `gh` CLI.
+
+### Rulesets (Preferred)
+
+Rulesets are the modern replacement for legacy branch protection. They support bypass actors, org-level inheritance, and granular enforcement.
+
+**Read rulesets:**
+
+```bash
+gh api repos/OWNER/REPO/rulesets
+gh api repos/OWNER/REPO/rulesets/RULESET_ID
+```
+
+**Create a ruleset:**
+
+```bash
+gh api repos/OWNER/REPO/rulesets --method POST --input - <<'EOF'
+{
+    "name": "main",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+        "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
+    },
+    "rules": [
+        { "type": "deletion" },
+        { "type": "non_fast_forward" },
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 1,
+                "require_code_owner_review": true,
+                "dismiss_stale_reviews_on_push": false,
+                "require_last_push_approval": false,
+                "required_review_thread_resolution": false,
+                "allowed_merge_methods": ["merge", "squash", "rebase"]
+            }
+        }
+    ],
+    "bypass_actors": [
+        { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+    ]
+}
+EOF
+```
+
+**Update / delete:**
+
+```bash
+gh api repos/OWNER/REPO/rulesets/RULESET_ID -X PUT --input - <<'EOF'
+{ ... }
+EOF
+
+gh api repos/OWNER/REPO/rulesets/RULESET_ID --method DELETE
+```
+
+### Bypass Actors
+
+| `actor_type` | `actor_id` values | Notes |
+|-------------|-------------------|-------|
+| `RepositoryRole` | 1=Read, 2=Triage, 3=Write, 4=Maintain, 5=Admin | Most common |
+| `OrganizationAdmin` | 0 | Org-wide admin bypass |
+| `Team` | Team database ID | Find via `gh api orgs/ORG/teams/SLUG` |
+
+`User` is **not** a valid actor type — use `RepositoryRole` instead.
+
+### Legacy Branch Protection
+
+Still works but rulesets are preferred. The legacy endpoint returns 404 when only rulesets are configured — check rulesets first.
+
+```bash
+gh api repos/OWNER/REPO/branches/main/protection
+
+gh api repos/OWNER/REPO/branches/main/protection \
+    --method PUT --input - <<'EOF'
+{
+    "required_status_checks": { "strict": true, "contexts": ["ci/build"] },
+    "enforce_admins": false,
+    "required_pull_request_reviews": { "required_approving_review_count": 1 },
+    "restrictions": null
+}
+EOF
+
+gh api repos/OWNER/REPO/branches/main/protection --method DELETE
+```
+
+### CODEOWNERS
+
+Lives in `.github/CODEOWNERS` (preferred), repo root, or `docs/`. Requires `require_code_owner_review: true` in a ruleset or legacy protection to enforce.
+
+```
+# Default owner for everything
+* @OWNER
+
+# Per-directory ownership
+/src/payments/ @payments-team
+/lib/           @OWNER
+```
+
+### Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| List rulesets | `gh api repos/OWNER/REPO/rulesets` |
+| View ruleset | `gh api repos/OWNER/REPO/rulesets/ID` |
+| Legacy protection | `gh api repos/OWNER/REPO/branches/BRANCH/protection` |
+| Check CODEOWNERS | `gh api repos/OWNER/REPO/contents/.github/CODEOWNERS` |
+| Repo settings | `gh repo edit OWNER/REPO --enable-squash-merge` |

--- a/skills/VersionControl/GitLab.md
+++ b/skills/VersionControl/GitLab.md
@@ -1,0 +1,82 @@
+## GitLab Repo Governance
+
+Branch protection, merge approvals, and push rules via `glab` CLI.
+
+### Protected Branches
+
+**Read protection:**
+
+```bash
+glab api projects/:id/protected_branches
+glab api projects/:id/protected_branches/main
+```
+
+**Set protection:**
+
+```bash
+glab api projects/:id/protected_branches --method POST \
+    -f name=main \
+    -f push_access_level=40 \
+    -f merge_access_level=40 \
+    -f allow_force_push=false
+```
+
+### Access Levels
+
+| Level | Role |
+|-------|------|
+| 0 | No access |
+| 30 | Developer |
+| 40 | Maintainer |
+| 60 | Admin |
+
+### Merge Request Approvals
+
+**Read approval rules:**
+
+```bash
+glab api projects/:id/approval_rules
+glab api projects/:id/merge_requests/:mr_iid/approval_rules
+```
+
+**Set project-level approvals:**
+
+```bash
+glab api projects/:id/approval_rules --method POST \
+    -f name="Default" \
+    -f approvals_required=2
+
+glab api projects/:id --method PUT \
+    -f merge_requests_author_approval=false \
+    -f reset_approvals_on_push=true
+```
+
+### Push Rules
+
+```bash
+glab api projects/:id/push_rule
+
+glab api projects/:id/push_rule --method PUT \
+    -f deny_delete_tag=true \
+    -f member_check=true \
+    -f commit_message_regex="^(feat|fix|docs|chore|refactor|test):"
+```
+
+### CODEOWNERS
+
+Lives in `CODEOWNERS` at repo root, `.gitlab/`, or `docs/`. Requires `code_owner_approval_required: true` on the protected branch to enforce.
+
+```bash
+glab api projects/:id/repository/files/CODEOWNERS?ref=main
+glab api projects/:id/repository/files/.gitlab%2FCODEOWNERS?ref=main
+```
+
+### Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| Protected branches | `glab api projects/:id/protected_branches` |
+| Approval rules | `glab api projects/:id/approval_rules` |
+| Push rules | `glab api projects/:id/push_rule` |
+| Project settings | `glab api projects/:id` |
+| Check CODEOWNERS | `glab api projects/:id/repository/files/CODEOWNERS?ref=main` |

--- a/skills/VersionControl/SKILL.md
+++ b/skills/VersionControl/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: VersionControl
+version: 0.1.0
+description: "Git best practices — conventional commits, staging, push policy, repo governance. USE WHEN committing, pushing, creating PRs, branch protection, rulesets, CODEOWNERS."
+---
+
+# VersionControl
+
+Git conventions and repo governance. Commit discipline, staging hygiene, and platform-specific branch protection.
+
+## Commit Messages
+
+Use conventional commit prefixes. Message should explain **why**, not what.
+
+| Prefix | Use when |
+|--------|----------|
+| `feat:` | New feature or capability |
+| `fix:` | Bug fix |
+| `refactor:` | Restructuring without behaviour change |
+| `docs:` | Documentation only |
+| `chore:` | Maintenance (deps, configs, CI) |
+| `test:` | Adding or fixing tests |
+
+Keep the first line under 72 characters. Add a blank line and body for context when the change is non-obvious.
+
+**Never** add `Co-Authored-By` trailers unless the user explicitly asks.
+
+## Staging
+
+- Stage specific files by name — never use `git add -A` or `git add .`
+- Review `git diff --staged` before committing
+- Never commit files that contain secrets (`.env`, credentials, API keys)
+
+## Push Policy
+
+- Never force-push (`--force`, `--force-with-lease`) unless the user explicitly asks
+- Never skip hooks (`--no-verify`) unless the user explicitly asks
+- Do not push unless the user asks — committing and pushing are separate actions
+
+## Pull Requests
+
+- Title under 70 characters — details go in the body
+- Body format: `## Summary` (1-3 bullets) + `## Test plan` (checklist)
+- Create from a feature branch, never directly from main
+
+## Repo Governance
+
+Platform-specific branch protection, rulesets, and code ownership.
+
+| Platform | CLI | Companion | Detect by |
+|----------|-----|-----------|-----------|
+| GitHub | `gh` | @GitHub.md | `github.com` in remote origin |
+| GitLab | `glab` | @GitLab.md | `gitlab.com` in remote origin |
+
+Auto-detect from the remote origin URL. If ambiguous, ask the user.
+
+### Principles
+
+- Prefer rulesets over legacy branch protection (GitHub) — rulesets are more granular and support bypass actors
+- Document governance in the repo itself (CODEOWNERS, branch rules) not just in external settings
+- Always read current rules before modifying — audit first, change second

--- a/skills/VersionControl/SKILL.yaml
+++ b/skills/VersionControl/SKILL.yaml
@@ -1,0 +1,4 @@
+sources:
+    - https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
+    - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+    - https://docs.gitlab.com/user/project/protected_branches/


### PR DESCRIPTION
## Summary

- Adds `VersionControl` skill — git conventions (commits, staging, push policy) and repo governance
- GitHub companion: rulesets (preferred), legacy branch protection, CODEOWNERS, bypass actors
- GitLab companion: protected branches, merge approvals, push rules, CODEOWNERS
- Migrated from forge-dev's Git skill, stripped module-specific content, added governance

## Test plan

- [ ] `make install && make verify` — skill deploys to all providers
- [ ] Verify SKILL.md passes `.mdschema` (frontmatter fields, heading depth)
- [ ] Invoke `/VersionControl` — confirm skill loads with companions