### PR TITLE
feat: mnemonic reference-style link labels

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,9 +116,9 @@ rules/
 Council skills MUST use agent teams. Always TeamCreate
 before spawning any agents.
 
-Never use bare Agent calls for council specialists. [1]
+Never use bare Agent calls for council specialists. [CC-AGENTS]
 
-[1]: https://docs.anthropic.com/en/docs/claude-code/sub-agents
+[CC-AGENTS]: https://docs.anthropic.com/en/docs/claude-code/sub-agents
 ```
 
 **Codex variant** (`rules/codex/AgentTeams.md`):
@@ -183,7 +183,7 @@ Base body                          Variant body
          ▼                                   ▼
 ```
 
-The variant body replaces the base entirely. No frontmatter in the variant, so nothing to strip. The base's wiki-refs (`[1]`) are extracted for provenance but don't appear in the output (the variant doesn't contain them).
+The variant body replaces the base entirely. No frontmatter in the variant, so nothing to strip. The base's reference links are extracted for provenance but don't appear in the output (the variant doesn't contain them).
 
 **Step 4:** Three files written to `.codex/rules/`
 
@@ -291,12 +291,12 @@ Variant files default to **replace** (swap entire base content). For partial ove
 Source files cite external authorities using GFM reference links:
 
 ```markdown
-Always parameterize SQL queries [1].
+Always parameterize SQL queries [OWASP].
 
-[1]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
+[OWASP]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
 ```
 
-At deploy time, `[N]` markers and the `[N]:` reference block are stripped from the deployed file. The extracted URLs flow into the `.prov.yaml` `sources:` array. See [ADR 0017](docs/decisions/CORE-0017 GFM Reference Links for Prompt Provenance.md) and [ADR 0020](docs/decisions/CORE-0020 W3C PROV Provenance Records.md).
+At deploy time, reference markers and the reference block are stripped from the deployed file. The extracted URLs flow into the `.prov.yaml` `sources:` array. See [ADR 0017](docs/decisions/CORE-0017 GFM Reference Links for Prompt Provenance.md) and [ADR 0020](docs/decisions/CORE-0020 W3C PROV Provenance Records.md).
 
 ### Output Summary
 
@@ -343,7 +343,7 @@ rules/*.md                           PromptProvenance scan
 
 | Check | Method | What it catches |
 |-------|--------|-----------------|
-| Missing provenance | No `[N]:` wiki-refs in source | Rules without external source citations |
+| Missing provenance | No mnemonic ref definitions in source | Rules without external source citations |
 | Missing targets | Provider-specific content without `targets:` | Rules that should be filtered per provider |
 | Needs qualifier split | References provider-specific tools/APIs | Rules that need variant directories |
 | Conflict detection | Scope overlap analysis (Arbiter-style) | Two rules that contradict each other |
@@ -508,7 +508,7 @@ Both exist. Hooks are preferred for anything that can be automated. Markdown cov
 
 ## References
 
-[1]: https://docs.anthropic.com/en/docs/claude-code/skills "Claude Code Skills"
-[2]: https://docs.anthropic.com/en/docs/claude-code/sub-agents "Claude Code Sub-agents"
-[3]: https://docs.anthropic.com/en/docs/claude-code/hooks "Claude Code Hooks"
-[4]: skills/BuildModule/SKILL.md "Forge Module Convention"
+[CC-SKILLS]: https://docs.anthropic.com/en/docs/claude-code/skills "Claude Code Skills"
+[CC-SUBAGENTS]: https://docs.anthropic.com/en/docs/claude-code/sub-agents "Claude Code Sub-agents"
+[CC-HOOKS]: https://docs.anthropic.com/en/docs/claude-code/hooks "Claude Code Hooks"
+[BUILD-MODULE]: skills/BuildModule/SKILL.md "Forge Module Convention"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 A build system for AI instructions. Treats prompts the way software engineering treats source code: authored in version-controlled markdown, validated by schemas, assembled per target, deployed with provenance records.
 
-Three artifact types map to how [Claude Code][1] loads instructions:
+Three artifact types map to how [Claude Code][CC] loads instructions:
 
-- **[Rules][2]** — small instruction files, always in context. One file, one behavior. When something goes wrong, the filename tells you which rule caused it.
-- **[Skills][3]** — lazy-loaded capabilities. The AI reads the description at session start but loads full instructions only when invoked.
-- **[Agents][4]** — markdown files that define a persona and role for agent delegation.
+- **[Rules][CC-RULES]** — small instruction files, always in context. One file, one behavior. When something goes wrong, the filename tells you which rule caused it.
+- **[Skills][CC-SKILLS]** — lazy-loaded capabilities. The AI reads the description at session start but loads full instructions only when invoked.
+- **[Agents][CC-AGENTS]** — markdown files that define a persona and role for agent delegation.
 
-This is not a plugin system. Plugins are deployed artifacts for end users (one-click install via [Cowork][5]). forge is what happens before that: authoring, validating, assembling, and tracking instructions across teams, models, and providers.
+This is not a plugin system. Plugins are deployed artifacts for end users (one-click install via [Cowork][COWORK]). forge is what happens before that: authoring, validating, assembling, and tracking instructions across teams, models, and providers.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the structural overview. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute.
 
@@ -76,7 +76,7 @@ Architecture Decision Records document the why behind structural choices. Each p
 | `PROV` | Manifest and provenance  | `PROV-0002 Manifest for Deployment Tracking` |
 | `MVPR` | Prompt optimization      | `MVPR-0001 Minimum Viable Prompt`            |
 
-ADRs use [structured-madr][6] frontmatter with forge extensions. Validate with `python3 bin/validate-adr.py templates/forge-adr.json docs/decisions/`.
+ADRs use [structured-madr][MADR] frontmatter with forge extensions. Validate with `python3 bin/validate-adr.py templates/forge-adr.json docs/decisions/`.
 
 ## Contributing
 
@@ -95,9 +95,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, skill autho
 
 [EUPL-1.2](LICENSE)
 
-[1]: https://code.claude.com/docs/en/overview
-[2]: https://code.claude.com/docs/en/memory
-[3]: https://code.claude.com/docs/en/skills
-[4]: https://code.claude.com/docs/en/sub-agents
-[5]: https://support.claude.com/en/articles/13837433-manage-cowork-plugins-for-your-organization
-[6]: https://github.com/zircote/structured-madr
+[CC]: https://code.claude.com/docs/en/overview
+[CC-RULES]: https://code.claude.com/docs/en/memory
+[CC-SKILLS]: https://code.claude.com/docs/en/skills
+[CC-AGENTS]: https://code.claude.com/docs/en/sub-agents
+[COWORK]: https://support.claude.com/en/articles/13837433-manage-cowork-plugins-for-your-organization
+[MADR]: https://github.com/zircote/structured-madr

--- a/docs/decisions/CORE-0001 Markdown as System Language.md
+++ b/docs/decisions/CORE-0001 Markdown as System Language.md
@@ -22,7 +22,7 @@ upstream: [MarkdownFirst.md]
 
 ## Context and Problem Statement
 
-The system needs a universal format for skills, agents, rules, documentation, journal templates, and configuration. This format must be readable by humans, consumable by AI tools across providers, and authorable without specialized tooling. It also needs to integrate with PKM tools where content is first-class — particularly [Obsidian][1], which has used YAML frontmatter since [2020][2] and adds `[[wikilinks]]`.
+The system needs a universal format for skills, agents, rules, documentation, journal templates, and configuration. This format must be readable by humans, consumable by AI tools across providers, and authorable without specialized tooling. It also needs to integrate with PKM tools where content is first-class — particularly [Obsidian][OBS], which has used YAML frontmatter since [2020][OBS-FM] and adds `[[wikilinks]]`.
 
 ## Decision Drivers
 
@@ -48,5 +48,5 @@ Chosen option: **Markdown with YAML frontmatter**. Everything is markdown — sk
 - [+] Same files render in Obsidian, GitHub, and AI tool contexts without conversion
 - [-] No compile-time validation of content logic — structural checks rely on mdschema, semantic correctness requires review
 
-[1]: https://obsidian.md/
-[2]: https://obsidian.md/changelog/2020-08-21-desktop-v0.8.5/
+[OBS]: https://obsidian.md/
+[OBS-FM]: https://obsidian.md/changelog/2020-08-21-desktop-v0.8.5/

--- a/docs/decisions/CORE-0002 Metadata Inside Files.md
+++ b/docs/decisions/CORE-0002 Metadata Inside Files.md
@@ -38,7 +38,7 @@ Knowledge management tools have historically taken two approaches: store metadat
 
 ## Considered Options
 
-1. **External database** — tools like [Evernote][1], [DEVONThink][2], [TheBrain][3], and [Bear][4] store metadata in a proprietary database outside the files. Queries are fast, but metadata is invisible when files are viewed in git, a text editor, or an AI tool's context window. Metadata is lost when files move between systems. The database becomes a single point of failure and vendor lock-in.
+1. **External database** — tools like [Evernote][EVERNOTE], [DEVONThink][DEVON], [TheBrain][BRAIN], and [Bear][BEAR] store metadata in a proprietary database outside the files. Queries are fast, but metadata is invisible when files are viewed in git, a text editor, or an AI tool's context window. Metadata is lost when files move between systems. The database becomes a single point of failure and vendor lock-in.
 2. **Separate sidecar files** — `.yaml` or `.json` files alongside each `.md`. Keeps data in the filesystem but doubles file count, sidecars drift from canonical content, and renaming or moving a file orphans its sidecar silently.
 3. **Metadata inside the file** — embed metadata directly in the file using a standard format. When a file moves, its metadata moves with it. Every tool that reads the file has immediate access to its metadata. No external dependency, no drift, no orphaning.
 
@@ -48,7 +48,7 @@ Metadata belongs inside the file it describes. Not in an external database, not 
 
 When a file moves, its metadata moves with it. When a file is read, its metadata is immediately available. When a file is deleted, its metadata is deleted. There is no synchronization problem because there is nothing to synchronize.
 
-[Obsidian][5] proved this at scale — a vault of thousands of markdown files with embedded frontmatter, queryable by Dataview, searchable by Properties, portable across machines via git. No database server, no sync service, no proprietary format.
+[Obsidian][OBS] proved this at scale — a vault of thousands of markdown files with embedded frontmatter, queryable by Dataview, searchable by Properties, portable across machines via git. No database server, no sync service, no proprietary format.
 
 The specific mechanism for embedding metadata in markdown files is YAML frontmatter.
 
@@ -59,8 +59,8 @@ The specific mechanism for embedding metadata in markdown files is YAML frontmat
 - **Positive:** Eliminates an entire class of bugs (orphaned metadata, stale sidecars, sync failures)
 - **Negative:** File size increases slightly — mitigated by frontmatter being compact YAML
 
-[1]: https://evernote.com/
-[2]: https://www.devontechnologies.com/apps/devonthink
-[3]: https://thebrain.com/
-[4]: https://bear.app/
-[5]: https://obsidian.md/
+[EVERNOTE]: https://evernote.com/
+[DEVON]: https://www.devontechnologies.com/apps/devonthink
+[BRAIN]: https://thebrain.com/
+[BEAR]: https://bear.app/
+[OBS]: https://obsidian.md/

--- a/docs/decisions/CORE-0003 YAML Frontmatter for Machine Readability.md
+++ b/docs/decisions/CORE-0003 YAML Frontmatter for Machine Readability.md
@@ -31,46 +31,46 @@ upstream: [ObsidianFrontmatter.md]
 
 The broader ecosystem has converged on YAML frontmatter as the standard metadata layer for markdown files:
 
-- [**Claude Code**][1] reads YAML frontmatter in `CLAUDE.md` and skill files to understand file purpose, version, and configuration without parsing the full body ([docs][2]).
-- [**Obsidian**][4] adopted YAML frontmatter as the basis for its [Properties][3] system — the native UI for viewing, editing, and querying file metadata. The [Dataview][5] and Tasks plugins query frontmatter fields for dynamic views.
-- **Static site generators** ([Jekyll][6], [Hugo][7], Astro, Eleventy) all use YAML frontmatter as the standard metadata format for content files.
+- [**Claude Code**][CC] reads YAML frontmatter in `CLAUDE.md` and skill files to understand file purpose, version, and configuration without parsing the full body ([docs][CC-DOCS]).
+- [**Obsidian**][OBS] adopted YAML frontmatter as the basis for its [Properties][OBS-PROPS] system — the native UI for viewing, editing, and querying file metadata. The [Dataview][DATAVIEW] and Tasks plugins query frontmatter fields for dynamic views.
+- **Static site generators** ([Jekyll][JEKYLL], [Hugo][HUGO], Astro, Eleventy) all use YAML frontmatter as the standard metadata format for content files.
 - **GitHub** renders YAML frontmatter as a formatted table at the top of markdown files in the web UI.
 
 This is not a project-specific convention — it is the de facto standard for markdown metadata across the tools this ecosystem depends on.
 
 ## Decision Drivers
 
-- [Obsidian][4] Properties requires YAML frontmatter — no frontmatter means no queryable metadata in the vault
-- [Claude Code][1] parses frontmatter to understand skill definitions, agent configurations, and rule files
+- [Obsidian][OBS] Properties requires YAML frontmatter — no frontmatter means no queryable metadata in the vault
+- [Claude Code][CC] parses frontmatter to understand skill definitions, agent configurations, and rule files
 - Schema validation via `mdschema` requires typed fields that can be checked by CI
 - Structured-madr adoption depends on a rich frontmatter convention
 - Every major markdown tool already expects YAML frontmatter — adopting it costs nothing and enables everything
 
 ## Considered Options
 
-1. **TOML frontmatter** — delimited by `+++`. Used by [Hugo][7] as an alternative. Less readable than YAML for nested structures, and [Obsidian][4] does not support it natively.
-2. **JSON frontmatter** — delimited by `{` / `}`. Valid in some static site generators but hostile to human authoring, no [Obsidian][4] support, and poor readability for lists and nested values.
-3. **YAML frontmatter** — delimited by `---` at the top of the file. Universally supported by markdown renderers, [Obsidian][4], [Claude Code][1], GitHub, and static site generators.
+1. **TOML frontmatter** — delimited by `+++`. Used by [Hugo][HUGO] as an alternative. Less readable than YAML for nested structures, and [Obsidian][OBS] does not support it natively.
+2. **JSON frontmatter** — delimited by `{` / `}`. Valid in some static site generators but hostile to human authoring, no [Obsidian][OBS] support, and poor readability for lists and nested values.
+3. **YAML frontmatter** — delimited by `---` at the top of the file. Universally supported by markdown renderers, [Obsidian][OBS], [Claude Code][CC], GitHub, and static site generators.
 
 ## Decision Outcome
 
-All markdown files carry YAML frontmatter delimited by `---`. Frontmatter holds machine-readable metadata; the prose body holds human-readable instructions. The same file works in a git repo, an [Obsidian][4] vault, and an AI tool's context window without conversion.
+All markdown files carry YAML frontmatter delimited by `---`. Frontmatter holds machine-readable metadata; the prose body holds human-readable instructions. The same file works in a git repo, an [Obsidian][OBS] vault, and an AI tool's context window without conversion.
 
-Frontmatter properties must be flat — [Obsidian][4]'s Properties panel cannot display nested YAML. Use strings or lists of strings only, never nested objects. YAML values containing `:` must be quoted.
+Frontmatter properties must be flat — [Obsidian][OBS]'s Properties panel cannot display nested YAML. Use strings or lists of strings only, never nested objects. YAML values containing `:` must be quoted.
 
 This decision precedes the MADR template choice because frontmatter is the mechanism; structured-madr is the schema that standardizes which fields appear in ADR frontmatter specifically.
 
 ### Consequences
 
-- **Positive:** Every file is queryable by [Dataview][5], validatable by `mdschema`, and parseable by AI tools without custom logic
+- **Positive:** Every file is queryable by [Dataview][DATAVIEW], validatable by `mdschema`, and parseable by AI tools without custom logic
 - **Positive:** Aligns with the dominant ecosystem convention — no migration cost, no custom tooling
 - **Positive:** Metadata travels with the file across systems, tools, and repos
-- **Negative:** Authors must maintain frontmatter alongside prose — stale metadata is a risk mitigated by CI validation and [Obsidian][4]'s Properties UI
+- **Negative:** Authors must maintain frontmatter alongside prose — stale metadata is a risk mitigated by CI validation and [Obsidian][OBS]'s Properties UI
 
-[1]: https://claude.ai/code
-[2]: https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview
-[3]: https://help.obsidian.md/properties
-[4]: https://obsidian.md/
-[5]: https://blacksmithgu.github.io/obsidian-dataview/
-[6]: https://jekyllrb.com/docs/front-matter/
-[7]: https://gohugo.io/content-management/front-matter/
+[CC]: https://claude.ai/code
+[CC-DOCS]: https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview
+[OBS-PROPS]: https://help.obsidian.md/properties
+[OBS]: https://obsidian.md/
+[DATAVIEW]: https://blacksmithgu.github.io/obsidian-dataview/
+[JEKYLL]: https://jekyllrb.com/docs/front-matter/
+[HUGO]: https://gohugo.io/content-management/front-matter/

--- a/docs/decisions/CORE-0007 Forge MADR Extensions.md
+++ b/docs/decisions/CORE-0007 Forge MADR Extensions.md
@@ -27,9 +27,9 @@ upstream: []
 
 ## Context and Problem Statement
 
-[CORE-0005](CORE-0005 ADR Template Choice.md) adopts [structured-madr][1] as the ADR template. The upstream schema covers universal ADR fields (title, description, type, category, tags, status, created, updated, author, project, related). But the forge ecosystem needs additional fields for RACI accountability, rule promotion tracking, and cross-repo provenance.
+[CORE-0005](CORE-0005 ADR Template Choice.md) adopts [structured-madr][MADR] as the ADR template. The upstream schema covers universal ADR fields (title, description, type, category, tags, status, created, updated, author, project, related). But the forge ecosystem needs additional fields for RACI accountability, rule promotion tracking, and cross-repo provenance.
 
-The [structured-madr schema][1] allows additional properties prefixed with `x-`, providing a sanctioned extension mechanism.
+The [structured-madr schema][MADR] allows additional properties prefixed with `x-`, providing a sanctioned extension mechanism.
 
 ## Decision Drivers
 
@@ -45,7 +45,7 @@ The [structured-madr schema][1] allows additional properties prefixed with `x-`,
 
 ## Decision Outcome
 
-Forge ADRs use `x-forge-` prefixed extension fields alongside [structured-madr][1] required fields. For brevity, the short form (without prefix) is the canonical name in forge repos. Both forms are valid in the schema.
+Forge ADRs use `x-forge-` prefixed extension fields alongside [structured-madr][MADR] required fields. For brevity, the short form (without prefix) is the canonical name in forge repos. Both forms are valid in the schema.
 
 ### Extension Fields
 
@@ -67,6 +67,6 @@ Forge ADRs use `x-forge-` prefixed extension fields alongside [structured-madr][
 
 - **Positive:** ADRs carry full accountability and provenance metadata
 - **Positive:** Extensions use the sanctioned `x-` mechanism — upstream schema validation passes
-- **Negative:** Forge ADRs have more frontmatter fields than upstream [structured-madr][1] — mitigated by all extension fields being optional
+- **Negative:** Forge ADRs have more frontmatter fields than upstream [structured-madr][MADR] — mitigated by all extension fields being optional
 
-[1]: https://github.com/zircote/structured-madr
+[MADR]: https://github.com/zircote/structured-madr

--- a/docs/decisions/CORE-0008 Variables in Markdown Instructions and Templates.md
+++ b/docs/decisions/CORE-0008 Variables in Markdown Instructions and Templates.md
@@ -28,7 +28,7 @@ upstream: [PlaintextTemplateVariables.md]
 
 Markdown instructions (skills, agents, rules) need to reference configurable values — file paths, directory locations, tool names, feature flags. Templates need placeholder values that get filled at creation time. Both must be resolvable by shell tools and readable by AI.
 
-Three placeholder patterns had emerged organically: inline descriptions ("Title — a short noun phrase"), `{{VARIABLE}}` ([Obsidian Templater][1] syntax), and `{VARIABLE}` (structured-madr convention). None of these are shell-resolvable.
+Three placeholder patterns had emerged organically: inline descriptions ("Title — a short noun phrase"), `{{VARIABLE}}` ([Obsidian Templater][TEMPLATER] syntax), and `{VARIABLE}` (structured-madr convention). None of these are shell-resolvable.
 
 ## Decision Drivers
 
@@ -67,4 +67,4 @@ Obsidian Templater templates continue using `{{VARIABLE}}`. The two patterns do 
 - [-] ENV vars must be populated before the instruction is useful — requires a config loading layer
 - [-] Two coexisting patterns (`${VAR}` and `{{VAR}}`) — mitigated by the rule that they never mix in one file
 
-[1]: https://silentvoid13.github.io/Templater/
+[TEMPLATER]: https://silentvoid13.github.io/Templater/

--- a/docs/decisions/CORE-0011 Verified Remote Execution.md
+++ b/docs/decisions/CORE-0011 Verified Remote Execution.md
@@ -31,7 +31,7 @@ CI pipelines and pre-commit hooks sometimes fetch scripts from the network. Blin
 - Remote scripts are convenient — always current, zero local maintenance
 - The risk is unverified execution, not remote fetching
 - A committed hash acts as a trust anchor — the script can change, but execution requires explicit hash update
-- Supply chain attacks target the gap between "fetched" and "verified" ([SLSA threat model][1])
+- Supply chain attacks target the gap between "fetched" and "verified" ([SLSA threat model][SLSA-THREATS])
 
 ## Considered Options
 
@@ -67,7 +67,7 @@ fi
 - [+] Remote scripts execute only when their content matches the committed hash
 - [+] Compromised upstream is detected immediately — hash mismatch blocks execution
 - [+] Fallback to local copy means CI never breaks due to network issues
-- [+] Consistent with SLSA build integrity requirements ([SLSA L2][2])
+- [+] Consistent with SLSA build integrity requirements ([SLSA L2][SLSA-LEVELS])
 - [-] Hash must be updated manually when adopting upstream changes (intentional friction)
 
 ## Links
@@ -75,5 +75,5 @@ fi
 - [SLSA Threats and mitigations](https://slsa.dev/spec/v1.0/threats) — supply chain threat model
 - [CORE-0010 Unified Module Validation](CORE-0010 Unified Module Validation.md) — the validation script this decision protects
 
-[1]: https://slsa.dev/spec/v1.0/threats
-[2]: https://slsa.dev/spec/v1.0/levels
+[SLSA-THREATS]: https://slsa.dev/spec/v1.0/threats
+[SLSA-LEVELS]: https://slsa.dev/spec/v1.0/levels

--- a/docs/decisions/PROV-0004 Reference Links for Prompt Provenance.md
+++ b/docs/decisions/PROV-0004 Reference Links for Prompt Provenance.md
@@ -29,7 +29,7 @@ AI instructions need traceable provenance — where did this knowledge come from
 
 ## Considered Options
 
-- **Reference-style links** — `[1]: https://owasp.org/...` in source, stripped at deploy
+- **Reference-style links** — `[OWASP]: https://owasp.org/...` in source, stripped at deploy
 - **Sidecar-only** — companion file carries all provenance metadata
 - **Inline HTML comments** — invisible in rendered markdown
 - **Extended frontmatter injected at deploy** — install binary adds metadata to deployed files
@@ -39,13 +39,13 @@ AI instructions need traceable provenance — where did this knowledge come from
 Chosen option: **Reference-style links**, because they're standard markdown, human-readable in source, and the install binary can strip them at deploy for zero token overhead. Stripping is configurable (`--provenance strip|inline`). External URLs extracted from stripped refs feed into provenance tracking records ([PROV-0003](PROV-0003 Provenance Tracking.md)).
 
 ```markdown
-Always parameterize SQL queries [1].
+Always parameterize SQL queries [OWASP].
 
-[1]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
+[OWASP]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
 ```
 
 ## Consequences
 
 - Positive: source files are self-documenting with auditable provenance
 - Positive: deployed files remain token-clean when stripping is enabled
-- Tradeoff: rules that cite external sources need `[N]:` reference blocks added
+- Tradeoff: rules that cite external sources need mnemonic reference blocks added

--- a/rules/ArchitectureDecisionRecords.md
+++ b/rules/ArchitectureDecisionRecords.md
@@ -1,7 +1,7 @@
-Architecture Decision Records capture the why behind structural choices as markdown files in `docs/decisions/`. We use [structured-madr][1] with custom extensions for RACI accountability and provenance tracking (`templates/forge-adr.md`, validated by `templates/forge-adr.json`).
+Architecture Decision Records capture the why behind structural choices as markdown files in `docs/decisions/`. We use [structured-madr][MADR] with custom extensions for RACI accountability and provenance tracking (`templates/forge-adr.md`, validated by `templates/forge-adr.json`).
 
 Required frontmatter: `title`, `description`, `type`, `category`, `tags`, `status`, `created`, `updated`, `author`, `project`. Status values are lowercase: `proposed`, `accepted`, `deprecated`, `superseded`.
 
 Before proposing architectural changes or challenging existing patterns, check the project's ADRs via the ArchitectureDecision skill. Do not contradict an accepted ADR without explicitly acknowledging it and proposing a superseding record.
 
-[1]: https://github.com/zircote/structured-madr
+[MADR]: https://github.com/zircote/structured-madr

--- a/rules/CanonSidecar.md
+++ b/rules/CanonSidecar.md
@@ -1,3 +1,3 @@
-Sidecars are companion files carrying metadata the canonical file shouldn't express. The canonical file is the source of truth. 
+Sidecars are companion files carrying metadata the canonical file shouldn't express. The canonical file is the source of truth.
 
 Never duplicate content from the canonical file into the sidecar. If a field exists in both, the canonical file wins and the sidecar copy is dead weight.

--- a/rules/InstallMd.md
+++ b/rules/InstallMd.md
@@ -1,8 +1,8 @@
-Every repository ships an `INSTALL.md` following the Mintlify install.md standard [1] for agent-executable installation. The file tells AI agents how to install and verify the software without polluting CLAUDE.md (behavioral), AGENTS.md (behavioral), or README.md (human-oriented).
+Every repository ships an `INSTALL.md` following the Mintlify install.md standard [MINTLIFY] for agent-executable installation. The file tells AI agents how to install and verify the software without polluting CLAUDE.md (behavioral), AGENTS.md (behavioral), or README.md (human-oriented).
 
 Required elements: H1 title, blockquote summary, conversational opening, OBJECTIVE, DONE WHEN (measurable success condition), TODO checklist (3-7 items), detailed steps with shell commands, EXECUTE NOW closing.
 
-DONE WHEN embeds verification — no separate VERIFY.md needed. Template at `templates/INSTALL.md` in forge-cli [2].
+DONE WHEN embeds verification — no separate VERIFY.md needed. Template at `templates/INSTALL.md` in forge-cli [TEMPLATE].
 
-[1]: https://github.com/mintlify/install-md "Mintlify install.md — standard for LLM-executable installation"
-[2]: https://github.com/N4M3Z/forge-cli/blob/main/templates/INSTALL.md "INSTALL.md template"
+[MINTLIFY]: https://github.com/mintlify/install-md "Mintlify install.md — standard for LLM-executable installation"
+[TEMPLATE]: https://github.com/N4M3Z/forge-cli/blob/main/templates/INSTALL.md "INSTALL.md template"

--- a/rules/MarkdownReflinks.md
+++ b/rules/MarkdownReflinks.md
@@ -1,0 +1,4 @@
+Reference-style link labels use mnemonic abbreviations derived from the source name, not numbers. The label should be recognizable at the call site without scrolling to the definition.
+
+Write: `[structured-madr][MADR]` with `[MADR]: https://github.com/zircote/structured-madr`
+Not: `[structured-madr][1]` with `[1]: https://github.com/zircote/structured-madr`

--- a/rules/ParameterizedQueries.md
+++ b/rules/ParameterizedQueries.md
@@ -1,5 +1,5 @@
-All SQL must use parameterized queries ([OWASP guidance][1]). No string interpolation or concatenation in query construction.
+All SQL must use parameterized queries ([OWASP guidance][OWASP]). No string interpolation or concatenation in query construction.
 
 Flag: string interpolation in SQL context, format strings with table/column names from user input, dynamic ORDER BY without allowlist. Accept: parameter placeholders with bound values via the database driver's parameter API.
 
-[1]: https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+[OWASP]: https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html

--- a/rules/PasswordHashing.md
+++ b/rules/PasswordHashing.md
@@ -1,5 +1,5 @@
-All credential storage must use bcrypt, argon2id, or scrypt ([OWASP guidance][1]). Plaintext passwords are forbidden in registration, login, and password reset flows.
+All credential storage must use bcrypt, argon2id, or scrypt ([OWASP guidance][OWASP]). Plaintext passwords are forbidden in registration, login, and password reset flows.
 
 When reviewing authentication code, verify that a proven hashing library is used. Flag any password property stored or compared as a raw string.
 
-[1]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+[OWASP]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

--- a/rules/SourceDataPoints.md
+++ b/rules/SourceDataPoints.md
@@ -1,3 +1,3 @@
 Every factual data point (number, date, limit, rate, threshold) must cite its origin via a markdown reference-style link. Unsourced claims are unreliable and unverifiable.
 
-Format: inline reference `([source][1])` with `[1]: https://...` at the bottom of the file. Primary/authoritative sources get the lowest indices.
+Format: inline reference `([source][OWASP])` with `[OWASP]: https://...` at the bottom of the file. Labels are mnemonic abbreviations derived from the source name, not numbers.

--- a/skills/ArchitectureDecision/SchemaValidation.md
+++ b/skills/ArchitectureDecision/SchemaValidation.md
@@ -4,16 +4,16 @@ Validate ADR frontmatter against JSON schemas. Two schemas are available:
 
 | Schema                           | Scope                         | Fields                                                                              |
 | -------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------- |
-| `templates/structured-madr.json` | Upstream [structured-madr][1] | title, description, type, category, tags, status, created, updated, author, project |
+| `templates/structured-madr.json` | Upstream [structured-madr][MADR] | title, description, type, category, tags, status, created, updated, author, project |
 | `templates/forge-adr.json`       | Forge ecosystem               | structured-madr + RACI, upstream, related                                           |
 
-The upstream [structured-madr][1] validator is sufficient for both schemas — forge-adr.json is a superset, and the validator accepts any schema file.
+The upstream [structured-madr][MADR] validator is sufficient for both schemas — forge-adr.json is a superset, and the validator accepts any schema file.
 
 ## Validation (preference order)
 
 ### 1. structured-madr local checkout
 
-Clone [structured-madr][1] to `~/Data/Developer/zircote/structured-madr` and use its npm validator:
+Clone [structured-madr][MADR] to `~/Data/Developer/zircote/structured-madr` and use its npm validator:
 
 ```sh
 git clone https://github.com/zircote/structured-madr.git ~/Data/Developer/zircote/structured-madr
@@ -57,4 +57,4 @@ When no other tool is available (Python 3 stdlib only):
 python3 bin/validate-adr.py templates/forge-adr.json docs/decisions/
 ```
 
-[1]: https://github.com/zircote/structured-madr
+[MADR]: https://github.com/zircote/structured-madr

--- a/skills/BuildPlugin/ClaudeMarketplace.md
+++ b/skills/BuildPlugin/ClaudeMarketplace.md
@@ -6,7 +6,7 @@ Add a module to a Claude Code plugin marketplace for Cowork distribution.
 
 - Module passes BuildPlugin validation
 - Module has a public GitHub repo (for plugin source)
-- Marketplace repo is **private** ([Cowork requirement][1])
+- Marketplace repo is **private** ([Cowork requirement][COWORK])
 - Cowork GitHub App installed on the marketplace repo
 
 ### Add to marketplace
@@ -89,6 +89,6 @@ If sync fails:
 - Confirm source URLs are accessible
 - Confirm `.claude-plugin/marketplace.json` is valid JSON
 
-[1]: https://support.claude.com/en/articles/13837433-manage-cowork-plugins-for-your-organization
-[2]: https://code.claude.com/docs/en/plugin-marketplaces
-[3]: https://code.claude.com/docs/en/plugins-reference
+[COWORK]: https://support.claude.com/en/articles/13837433-manage-cowork-plugins-for-your-organization
+[MARKETPLACE]: https://code.claude.com/docs/en/plugin-marketplaces
+[PLUGINS-REF]: https://code.claude.com/docs/en/plugins-reference

--- a/skills/PromptAnalysis/Provenance.md
+++ b/skills/PromptAnalysis/Provenance.md
@@ -4,11 +4,11 @@ Check whether rules cite external authoritative sources using GFM reference link
 
 ## What It Checks
 
-Scan each `.md` file for `[N]:` reference link definitions. These should point to external sources — OWASP cheat sheets, CVEs, model advisories, team decisions, standards documents — not to other forge rules.
+Scan each `.md` file for mnemonic reference link definitions. These should point to external sources — OWASP cheat sheets, CVEs, model advisories, team decisions, standards documents — not to other forge rules.
 
 ## Detection Pattern
 
-Count lines matching `^\[\d+\]:` in the file body (after frontmatter).
+Count lines matching `^\[[A-Z][-A-Z0-9]*\]:` in the file body (after frontmatter).
 
 | Count | Status  | Action                           |
 |-------|---------|----------------------------------|
@@ -18,20 +18,20 @@ Count lines matching `^\[\d+\]:` in the file body (after frontmatter).
 ## What Good Provenance Looks Like
 
 ```markdown
-Always parameterize SQL queries [1].
-Validate generated code for path traversal [2].
+Always parameterize SQL queries [OWASP].
+Validate generated code for path traversal [CVE-1234].
 
-[1]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
-[2]: https://cve.example.com/2026-1234
+[OWASP]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
+[CVE-1234]: https://cve.example.com/2026-1234
 ```
 
-References point to external knowledge. At deploy time, `[N]` markers and the reference block are stripped (PROV-0004). The extracted URLs flow into the provenance record (PROV-0003).
+References point to external knowledge. At deploy time, reference markers and the reference block are stripped (PROV-0004). The extracted URLs flow into the provenance record (PROV-0003).
 
 ## What Bad Provenance Looks Like
 
-- `[1]: forge-steering:rules/UseRTK.md` — self-referential, points to another rule
+- `[USERTK]: forge-steering:rules/UseRTK.md` — self-referential, points to another rule
 - No refs at all — the rule has no documented source
-- `[1]: https://example.com` — placeholder URL
+- `[EXAMPLE]: https://example.com` — placeholder URL
 
 ## Severity
 

--- a/skills/PromptAnalysis/Static/ArbiterRules.md
+++ b/skills/PromptAnalysis/Static/ArbiterRules.md
@@ -69,4 +69,4 @@ Initial space: O(n^2 x R) where n = blocks, R = rules. For 56 blocks and 5 rules
 
 Critical findings: TodoWrite mandate contradicts commit and PR restrictions (4 patterns). Scope overlap: read-before-edit restated across general section, Edit tool, and Write tool definitions.
 
-[1]: https://arxiv.org/html/2603.08993v1 "Arbiter paper"
+[ARBITER]: https://arxiv.org/html/2603.08993v1 "Arbiter paper"

--- a/skills/PromptAnalysis/Static/ArbiterScourer.md
+++ b/skills/PromptAnalysis/Static/ArbiterScourer.md
@@ -37,4 +37,4 @@ Three consecutive models setting `should_send_another: false` triggers terminati
 
 To run Arbiter-style scouring on a forge module's deployed prompt, assemble all rules into one document and send through multiple models sequentially. Each model receives the full prompt + prior findings. Collect findings until convergence.
 
-[1]: https://arxiv.org/html/2603.08993v1 "Arbiter paper"
+[ARBITER]: https://arxiv.org/html/2603.08993v1 "Arbiter paper"

--- a/skills/PromptAnalysis/Static/ArbiterTaxonomy.md
+++ b/skills/PromptAnalysis/Static/ArbiterTaxonomy.md
@@ -49,4 +49,4 @@ Non-monotonic discovery: pass 7 (MiniMax) produced 20 findings after pass 6 yiel
 | Flat         | Simplicity trade-offs                   | Identity confusion, leaked implementation details    |
 | Modular      | Design-level bugs at composition seams  | Gemini save_memory data loss during compression      |
 
-[1]: https://arxiv.org/html/2603.08993v1 "Arbiter paper"
+[ARBITER]: https://arxiv.org/html/2603.08993v1 "Arbiter paper"


### PR DESCRIPTION
## Summary

- Add `rules/MarkdownReflinks.md` — reference-style link labels use mnemonic abbreviations derived from the source name (e.g. `[OWASP]`, `[MADR]`), not numeric indices
- Replace all numeric `[1]`..`[N]` reference links across 21 files (rules, skills, agents, ADRs, README, ARCHITECTURE) with descriptive labels
- Update `skills/PromptAnalysis/Provenance.md` detection patterns to match the new mnemonic format

## Test plan

- [ ] Verify no numeric reference definitions remain: `grep -rn '^\[\d\+\]:' **/*.md`
- [ ] Verify no orphaned numeric inline references: `grep -rn '\]\[\d\+\]' **/*.md` (only the "Not:" example in MarkdownReflinks.md should match)
- [ ] Spot-check rendered links in GitHub preview for README.md and ARCHITECTURE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)