### PR TITLE
feat: hook scripts, SecretScan skill, forge init baseline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+quality:
+    image: python:3.12
+    stage: test
+    before_script:
+        - pip install ruff semgrep prek
+        - apt-get update && apt-get install -y gitleaks shellcheck
+    script:
+        - prek run --all-files
+    rules:
+        - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/.manifest
+++ b/.manifest
@@ -1,0 +1,28 @@
+.gitattributes:
+  fingerprint: d60f352d0db1404c70afb4bb8b2ca3fd1c610572aa40720e8a0b7baa7885418c
+  provenance: .provenance/.gitattributes.yaml
+.githooks:
+  pre-commit:
+    fingerprint: aaa2ebe74042b0f2f0169bf8587c1728d579b1223c3ec6f42e73e90f88ae4ed1
+    provenance: .githooks/.provenance/pre-commit.yaml
+.gitlab-ci.yml:
+  fingerprint: 424d6bde355c60f41b64a71c1a46baa1c7f07a861187923ccca7bf21d29f4b2b
+  provenance: .provenance/.gitlab-ci.yaml
+.gitleaks.toml:
+  fingerprint: 124bdbb5a4901a47e119dc7597b21003bdd4787c67b2757f975e238a956a226e
+  provenance: .provenance/.gitleaks.yaml
+LICENSE:
+  fingerprint: 57fb42fbcd0b037ce528ed8f72f1ec095d67bc6825ecf1448ff39be1fe68a4b4
+  provenance: .provenance/LICENSE.yaml
+agents:
+  .mdschema:
+    fingerprint: ae52030ed8dd0761400444b8f5f7b9de8af4677d9c84729dbdeb98719234457f
+    provenance: agents/.provenance/.mdschema.yaml
+rules:
+  .mdschema:
+    fingerprint: 4e6c78b7d14eeef521baf44acd73a6201e76174002bff5f83c2f699f0a2e6ed8
+    provenance: rules/.provenance/.mdschema.yaml
+skills:
+  .mdschema:
+    fingerprint: 6b7e7a30c6c6ce613f60997a7dec5520b6fac000a3fea8d1258138cf01504b41
+    provenance: skills/.provenance/.mdschema.yaml

--- a/.provenance/.gitattributes.yaml
+++ b/.provenance/.gitattributes.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: .gitattributes
+          digest:
+              sha256: d60f352d0db1404c70afb4bb8b2ca3fd1c610572aa40720e8a0b7baa7885418c
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/.gitattributes
+                  digest:
+                      sha256: d60f352d0db1404c70afb4bb8b2ca3fd1c610572aa40720e8a0b7baa7885418c
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.257341+00:00"

--- a/.provenance/.gitlab-ci.yaml
+++ b/.provenance/.gitlab-ci.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: .gitlab-ci.yml
+          digest:
+              sha256: 424d6bde355c60f41b64a71c1a46baa1c7f07a861187923ccca7bf21d29f4b2b
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/.gitlab-ci.yml
+                  digest:
+                      sha256: 424d6bde355c60f41b64a71c1a46baa1c7f07a861187923ccca7bf21d29f4b2b
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.258099+00:00"

--- a/.provenance/.gitleaks.yaml
+++ b/.provenance/.gitleaks.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: .gitleaks.toml
+          digest:
+              sha256: 124bdbb5a4901a47e119dc7597b21003bdd4787c67b2757f975e238a956a226e
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/.gitleaks.toml
+                  digest:
+                      sha256: 124bdbb5a4901a47e119dc7597b21003bdd4787c67b2757f975e238a956a226e
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.258256+00:00"

--- a/.provenance/LICENSE.yaml
+++ b/.provenance/LICENSE.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: LICENSE
+          digest:
+              sha256: 57fb42fbcd0b037ce528ed8f72f1ec095d67bc6825ecf1448ff39be1fe68a4b4
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/LICENSE
+                  digest:
+                      sha256: 57fb42fbcd0b037ce528ed8f72f1ec095d67bc6825ecf1448ff39be1fe68a4b4
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.259482+00:00"

--- a/agents/.provenance/.mdschema.yaml
+++ b/agents/.provenance/.mdschema.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: agents/.mdschema
+          digest:
+              sha256: ae52030ed8dd0761400444b8f5f7b9de8af4677d9c84729dbdeb98719234457f
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/agents/.mdschema
+                  digest:
+                      sha256: ae52030ed8dd0761400444b8f5f7b9de8af4677d9c84729dbdeb98719234457f
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.259975+00:00"

--- a/rules/.provenance/.mdschema.yaml
+++ b/rules/.provenance/.mdschema.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: rules/.mdschema
+          digest:
+              sha256: 4e6c78b7d14eeef521baf44acd73a6201e76174002bff5f83c2f699f0a2e6ed8
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/rules/.mdschema
+                  digest:
+                      sha256: 4e6c78b7d14eeef521baf44acd73a6201e76174002bff5f83c2f699f0a2e6ed8
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.260621+00:00"

--- a/rules/GitConventions.md
+++ b/rules/GitConventions.md
@@ -4,4 +4,6 @@ Default branch is `main`. Never use `master` — when creating repos, initializi
 
 Never add `Co-Authored-By` trailers to git commits unless the user explicitly asks to co-author.
 
+Never skip hooks (`--no-verify`) or bypass signing (`--no-gpg-sign`, `-c commit.gpgsign=false`) unless the user has explicitly asked for it. If a hook fails, investigate and fix the underlying issue.
+
 Before pushing to main, squash fix/chore/test commits into their parent `feat:` commit. Git history on main should read as a sequence of features, not a trail of corrections.

--- a/rules/GitConventions.md
+++ b/rules/GitConventions.md
@@ -7,3 +7,5 @@ Never add `Co-Authored-By` trailers to git commits unless the user explicitly as
 Never skip hooks (`--no-verify`) or bypass signing (`--no-gpg-sign`, `-c commit.gpgsign=false`) unless the user has explicitly asked for it. If a hook fails, investigate and fix the underlying issue.
 
 Before pushing to main, squash fix/chore/test commits into their parent `feat:` commit. Git history on main should read as a sequence of features, not a trail of corrections.
+
+PR titles and commit messages describe what changed, not why it was discovered. Never use "session learnings", "council findings", or similar process artifacts as framing. The change stands on its own.

--- a/rules/HookScripts.md
+++ b/rules/HookScripts.md
@@ -1,0 +1,7 @@
+Hook scripts MUST exit 0 always. A non-zero exit crashes the hook silently — Claude Code treats it as a hook failure, not a block decision. Communication is via stdout JSON only — stderr is invisible to Claude Code.
+
+- Empty stdout = allow
+- `{"decision":"block","reason":"..."}` = block (Stop)
+- `{"hookSpecificOutput":{"additionalContext":"..."}}` = AI context injection (PostToolUse)
+
+Guard files use `$PPID` or `$SESSION_ID` scoping to prevent repeat firing within a session.

--- a/rules/SecretScan.md
+++ b/rules/SecretScan.md
@@ -1,0 +1,10 @@
+Use `.gitleaks.toml` for path exclusions instead of `.gitleaksignore` fingerprints. Fingerprints break when line numbers shift. Path exclusions are stable:
+
+```toml
+[allowlist]
+paths = [
+    "evals/baselines/.*",
+]
+```
+
+Different gitleaks versions (apt vs homebrew vs GitHub Action) detect different patterns. If local scans pass but CI fails, the version mismatch is the likely cause.

--- a/rules/UseForge.md
+++ b/rules/UseForge.md
@@ -5,3 +5,5 @@ Assembly deploys only `.md` files. Non-markdown files (Python scripts, shell scr
 `--force` overwrites user-modified deployed files but does not re-assemble from source. Clear the build cache (`rm -rf build/`) before reinstalling if source changed since last assembly.
 
 `--target ~` deploys to user scope (`~/.claude/`, `~/.codex/`, etc.). The flag sets the base directory for provider directories. `--target ~/.claude` is wrong — it nests `~/.claude/.claude/`.
+
+In CI, install forge via the composite action: `uses: N4M3Z/forge-cli/.github/actions/setup-forge@main`. Supports version pinning (`version: v0.3.0`), caching, and platform detection.

--- a/skills/.provenance/.mdschema.yaml
+++ b/skills/.provenance/.mdschema.yaml
@@ -1,0 +1,23 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: skills/.mdschema
+          digest:
+              sha256: 6b7e7a30c6c6ce613f60997a7dec5520b6fac000a3fea8d1258138cf01504b41
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://github.com/N4M3Z/forge-cli/init/v1
+            externalParameters:
+                source: https://github.com/N4M3Z/forge-cli
+            resolvedDependencies:
+                - uri: templates/init/skills/.mdschema
+                  digest:
+                      sha256: 6b7e7a30c6c6ce613f60997a7dec5520b6fac000a3fea8d1258138cf01504b41
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-04-07T21:06:24.260945+00:00"

--- a/skills/SecretScan/SKILL.md
+++ b/skills/SecretScan/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: SecretScan
+description: "Commit-time secret scanning with gitleaks — prevent credentials from entering git history. USE WHEN scanning for leaked secrets, setting up pre-commit hooks, or auditing repositories for credentials."
+version: 0.1.0
+---
+
+# SecretScan
+
+Prevent secrets from entering git history using [gitleaks][GITLEAKS].
+
+## Setup
+
+### Install
+
+```sh
+brew install gitleaks
+```
+
+### Scan the working tree
+
+```sh
+gitleaks detect --source . --no-git
+```
+
+### Scan git history
+
+```sh
+gitleaks detect --source .
+```
+
+### Baseline known findings
+
+If the repo has historical secrets that have been rotated, create a baseline so future scans only flag new leaks:
+
+```sh
+gitleaks detect --source . --report-path .gitleaks-baseline.json
+gitleaks detect --source . --baseline-path .gitleaks-baseline.json
+```
+
+## Pre-commit hook
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+- id: gitleaks
+  name: gitleaks
+  entry: gitleaks detect --no-banner --no-git -s .
+  language: system
+  pass_filenames: false
+```
+
+## .gitleaks.toml
+
+Config file at the project root for allowlists. Use path exclusions, not fingerprints — fingerprints break when line numbers shift:
+
+```toml
+[allowlist]
+paths = [
+    "evals/baselines/.*",
+    "tests/fixtures/.*",
+]
+```
+
+## Constraints
+
+- Never commit `.env`, credentials, or API keys — even to private repos
+- If gitleaks blocks a commit, fix the leak. Don't bypass with `--no-verify`.
+- Different gitleaks versions detect different patterns. If local passes but CI fails, check version mismatch.
+
+[GITLEAKS]: https://github.com/gitleaks/gitleaks

--- a/skills/SecretScan/SKILL.yaml
+++ b/skills/SecretScan/SKILL.yaml
@@ -1,0 +1,2 @@
+sources:
+    - https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
## Summary

- New rule: `HookScripts.md` — exit 0 always, stdout JSON protocol, guard file pattern
- Update `GitConventions.md` — explicit `--no-verify` ban
- Update `UseForge.md` — reference setup-forge composite action for CI

## Skipped (already covered elsewhere)

- Secret scanning `.gitleaks.toml` pattern → forge-tlp/SecretScan skill
- Branch protection conventions → operational, not a rule
- Parallel hook execution → covered in HookScripts