### PR TITLE
feat: community skill adoption pipeline

### DIFF
--- a/docs/decisions/ARCH-0012 Community Adoption Strategy.md
+++ b/docs/decisions/ARCH-0012 Community Adoption Strategy.md
@@ -1,0 +1,116 @@
+---
+title: "Community Adoption Strategy"
+description: "Forge adopts a small, selective set of community skills under explicit scope, excluding rules and agents, with productization deferred until the pattern proves out"
+type: adr
+category: architecture
+tags:
+    - architecture
+    - adoption
+    - strategy
+    - curation
+status: accepted
+created: 2026-04-16
+updated: 2026-04-16
+author: "@N4M3Z"
+project: forge-core
+related:
+    - "ARCH-0001 Skills Agents and Rules.md"
+    - "MVPR-0001 Minimum Viable Prompt.md"
+responsible: ["@N4M3Z"]
+accountable: ["@N4M3Z"]
+consulted: []
+informed: []
+upstream: []
+---
+
+# Community Adoption Strategy
+
+## Context and Problem Statement
+
+Third-party catalogs like [aitmpl.com][AITMPL] (backed by [davila7/claude-code-templates][CCT]) ship ~1000 artifacts with no editorial gating, no schema enforcement, and no blocking CI. Research of the top-installed skills found that only 10-25% pass basic quality checks after transform, install counts correlate with category naming rather than utility (npm-hit counters, not unique adopters), and no competitor occupies the schema-validated, provenance-tracked, adversarially-reviewed quality tier.
+
+Forge needs a strategy that decides what to adopt, how much, under what rules, and what to explicitly not build. Without this ADR, each adoption becomes an ad-hoc judgment call, and productization infrastructure risks being built speculatively before any adoption is done.
+
+The adoption *mechanism* is captured in [ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md); the provenance *schema* in [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md). This ADR is strategic: it defines scope, inclusion rules, exclusion rules, and the deferred work.
+
+## Decision Drivers
+
+- Catalog volume is a losing category against npm-distributed community aggregators; coherence per skill is the defensible axis
+- Context budget is a first-class constraint ([MVPR-0001](MVPR-0001 Minimum Viable Prompt.md)) — every always-loaded token is paid every turn, forever
+- Research showed top-installed community skills are heavily biased toward interchangeable "senior-X" role prompts and first-party Anthropic wrappers; genuine novelty is rare
+- Forge is maintainer infrastructure for the author and their clients, not a product in a growth race — audience-of-one eliminates the forcing function that would justify heavy productization scaffolding
+- Skills abstract patterns; patterns emerge from practice, so any tooling built before multiple adoptions have happened will encode assumed taste rather than observed behavior
+
+## Considered Options
+
+1. **Transform-Only Import** — every upstream candidate runs through an automated multi-metric gate and transform pipeline, landing as forge-authored content. High machinery cost before first adoption.
+2. **Tier-Gated Passthrough** — three tiers (quarantine/community/trusted) with distinct gates. Three-times the maintenance surface; skills rot in quarantine.
+3. **Verified Marketplace** — forge publishes signed attestations on community skills via aitmpl and similar. Dependent on upstream PR acceptance (82 open PRs against a solo maintainer — ~70% vanity probability).
+4. **Selective Extraction** — hand-port only the 5-10% of upstream genuinely worth carrying. No automated ingest. Minimal machinery. Honest about scale.
+5. **Differentiated Fork** — fork the upstream, strip to the passing subset, publish as a minified catalog. Fork-sync burden one maintainer cannot sustain.
+6. **MCP Runtime Proxy** — expose community skills on demand via an MCP server with budget-gated runtime injection. Elegant but MCP support is uneven across providers and adds latency per invocation.
+
+## Decision Outcome
+
+Chosen option: **Selective Extraction**. Forge adopts a small, bounded set of community skills under explicit rules, with every other option deferred or deleted.
+
+### Strategic scope
+
+- **Target volume**: 3-5 hand-adoptions in the initial phase. Not 10, not 30 — selective means selective.
+- **Selection criterion**: only skills the maintainer will actually invoke. Adopting skills that won't be run is theater; quality judgment requires exercise, not catalog coverage.
+- **Rate of adoption**: bounded by hand, not by pipeline. Weeks-to-months per skill, not hours.
+
+### Inclusion rules
+
+- Skills only. The adoption surface is the skills artifact class; rules and agents are excluded from community intake.
+- Upstream source must be licensable (MIT, Apache, EUPL, or equivalent) and pinnable to a commit SHA — no floating branches.
+- The skill must measurably improve on or fill a gap that existing forge skills do not cover.
+
+### Exclusion rules
+
+- **Rules never flow through community adoption.** Rules are always-loaded and token-taxed on every turn; their identity-shaping effect makes them unsuitable for external authorship.
+- **Agents never flow through community adoption.** Agents are persona-heavy; a community agent would dilute forge's voice.
+- **Adopted skill names must not collide with first-party names.** Adoption lineage is a provenance property, not a directory property; two skills with the same name cannot coexist. Collisions are resolved by renaming the adoption or rejecting it.
+- Skills that duplicate a forge-authored skill without demonstrable delta are rejected, regardless of upstream install count.
+
+### Deferred / deleted work
+
+- **Automated ingest pipeline** (Strategy 1): deferred until hand-adoptions have surfaced a stable enough pattern that encoding it in code is worth the cost. Not before Phase 3.
+- **Publishing pipeline and verified-marketplace submissions** (Strategy 3): deleted from the current plan. If productization becomes interesting, a new ADR captures it from the artifacts accumulated — not speculatively built now.
+- **Rejection log**: not shipped in v1. If the absence of rejection records bites during Phase 2 evaluation, add a `.rejected/` log then. Don't build for hypothetical survivorship bias concerns now.
+- **External-adopter recruitment**: not pursued in v1. Forge is personal and professional curation; the forcing function of external users is deliberately absent.
+
+### Phases of execution
+
+1. **Hand-adopt** 3-5 candidate skills via the mechanism in [ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md). Each adoption produces an artifact plus provenance sidecar, placed in whichever existing module is the most natural domain home.
+2. **Derive evals** from the accumulated corpus — glob the provenance sidecars across `Modules/`, observe what transforms actually happened, what manual effort each adoption cost, what commit messages captured as rationale.
+3. **Decide on Phase 3** only after Phase 2 yields a rubric. If the evals do not produce consistent, generalizable criteria, the algorithmic `forge rate` CLI is not built. The strategy ends at Phase 2.
+
+### Acknowledged risks, not mitigated
+
+- **Audience-of-one eliminates the forcing function.** Personal curation with no external adopters drifts toward "maintainer didn't hit friction this week." Accepted — the output serves the maintainer's stack, not a market.
+- **Evals reflect maintainer taste.** A corpus of 3-5 adoptions by one curator is introspection, not research. If Phase 3's CLI ever ships, its description must name this limitation explicitly.
+- **Selective extraction has low velocity.** Days-to-weeks per adoption, not hours. Accepted; this is a feature of the strategy, not a cost to minimize.
+
+### Consequences
+
+- [+] No productization infrastructure is built speculatively; every component ships only after its need is demonstrated through practice
+- [+] The scope is small enough that scope creep is visible — any drift toward "adopt this too because it's popular" violates the stated selection criterion
+- [+] Rules and agents exclusion preserves forge's always-loaded coherence and voice; community intake cannot erode them
+- [-] Forge will appear small next to aitmpl-class catalogs; external discovery of forge's adopted skills is not a goal
+- [-] The maintainer carries 100% of the judgment load; no process redundancy, no external reviewers; bus factor of one for adoption decisions
+
+## Related Decisions
+
+- [ARCH-0001](ARCH-0001 Skills Agents and Rules.md) — the three-artifact model; this ADR restricts community intake to skills only
+- [ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md) — the mechanism implementing this strategy
+- [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) — the schema capturing adoption lineage and transform history
+- [MVPR-0001](MVPR-0001 Minimum Viable Prompt.md) — the context-budget principle driving selective adoption over volume
+
+## Links
+
+- [aitmpl.com][AITMPL] — the reference community catalog driving this decision
+- [davila7/claude-code-templates][CCT] — upstream repository and npm distribution
+
+[AITMPL]: https://www.aitmpl.com/ "Claude Code Templates catalog"
+[CCT]: https://github.com/davila7/claude-code-templates "Upstream repository"

--- a/docs/decisions/ARCH-0013 Markdown-First Adoption Mechanism.md
+++ b/docs/decisions/ARCH-0013 Markdown-First Adoption Mechanism.md
@@ -1,0 +1,108 @@
+---
+title: "Markdown-First Adoption Mechanism"
+description: "Community skills are adopted through a workflow skill composing per-transform skills as build steps, producing first-class markdown artifacts in their natural domain location"
+type: adr
+category: architecture
+tags:
+    - architecture
+    - adoption
+    - skills
+    - mechanism
+status: accepted
+created: 2026-04-16
+updated: 2026-04-16
+author: "@N4M3Z"
+project: forge-core
+related:
+    - "ARCH-0001 Skills Agents and Rules.md"
+    - "ARCH-0002 Skills Companion Files.md"
+    - "ARCH-0012 Community Adoption Strategy.md"
+    - "PROV-0006 Adoption Metadata in Provenance Sidecars.md"
+    - "CORE-0001 Markdown as System Language.md"
+responsible: ["@N4M3Z"]
+accountable: ["@N4M3Z"]
+consulted: []
+informed: []
+upstream: []
+---
+
+# Markdown-First Adoption Mechanism
+
+## Context and Problem Statement
+
+[ARCH-0012](ARCH-0012 Community Adoption Strategy.md) fixed the strategic decision: selective extraction of 3-5 community skills. This ADR decides the mechanism — the concrete primitive the maintainer uses to perform an adoption, how transforms compose, and where the output lives.
+
+The temptation is to scaffold a `forge adopt` CLI with gates, transforms, and an ingest pipeline before a single adoption has been performed. That encodes assumed taste before the taste exists. The mechanism decision holds the line on authoring conventions while the adoption practice is still too young to compile.
+
+## Decision Drivers
+
+- [CORE-0001](CORE-0001 Markdown as System Language.md) — markdown is the system language; skills, rules, agents, ADRs are all authored as markdown, making "build a markdown skill" the lowest-friction move
+- Skills abstract patterns; with zero adoptions done, any CLI schema would be a guess, not a codification
+- Adopted skills belong with their domain peers, not segregated by source — a security skill sits next to other security content regardless of who wrote it originally
+- Transforms like debranding, minimizeing, and rescoping are themselves reusable patterns that apply beyond adoption — forge's own skills could be debranded, and any prompt-shaped content can be shrunk — so they deserve to be skills in their own right, not hardcoded verbs
+- Cowork drops plugin hooks silently; a skill-based mechanism survives the Cowork runtime without ceremony
+
+## Considered Options
+
+1. **CLI-first** — ship `forge adopt <url>` as a subcommand from day one with transforms encoded as internal functions. Pattern-guessing before evidence.
+2. **Single monolithic workflow skill** — `/ForgeAdopt` as a standard skill with all transform logic embedded in its body. Simple but bundles unrelated concerns (debranding a vendor reference vs minimizeing pep-talk prose).
+3. **Workflow skill composing per-transform skills as build steps** — `/ForgeAdopt` as the orchestrator; each transform (`/DebrandPrompt`, `/MinimizePrompt`, `/RescopePrompt`, `/AlignPrompt`, `/ExtractPrompt`) is a separate skill invoked as a build step. Transforms become reusable outside adoption and each pins independently in provenance.
+
+## Decision Outcome
+
+Chosen option: **workflow skill composing per-transform skills as build steps.**
+
+`/ForgeAdopt` is a standard skill at `skills/ForgeAdopt/SKILL.md`, following the existing skill `.mdschema` ([ARCH-0001](ARCH-0001 Skills Agents and Rules.md), [ARCH-0002](ARCH-0002 Skills Companion Files.md)). It orchestrates a sequence of per-transform skills, each of which is a first-class skill usable independently of adoption.
+
+### Input
+
+A single upstream URL. The skill fetches the upstream content (via `WebFetch`, `gh api`, or an upstream-specific CLI against a scratch directory — whichever is cheapest for the source), records the commit SHA, reads the source, and makes the transform decisions inline.
+
+Sources are identified by URL, not hardcoded. When a second catalog appears, the skill handles it the same way.
+
+### Output
+
+Every successful adoption produces two files placed in whatever domain home fits best:
+
+- `skills/<Name>/SKILL.md` — a working skill. Same schema as any other skill. Invocable, testable, deployable. Carries `upstream: <url>` in frontmatter as a human-facing pointer — no SHA (see [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md)).
+- `skills/<Name>/.provenance/SKILL.yaml` — the SLSA sidecar. Each transform skill applied appears as a `resolvedDependencies` entry with its pinned digest; the upstream source is another entry. See [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) for the schema.
+
+Choosing the destination is part of the adoption decision. In a project with multiple scopes (modules, subtrees, plugins), the skill goes where its domain already lives; in a single-scope project, there is only one `skills/` directory and the question does not arise. If no existing home is a natural fit, the adoption is deferred — creating new structure just to house one imported skill is over-engineering. The commit that lands the adoption captures the placement reasoning in its message.
+
+Companion files (where upstream content is better extracted than inlined) follow [ARCH-0002](ARCH-0002 Skills Companion Files.md) — same `@` include conventions as any skill.
+
+### Transform skills (build steps)
+
+Each transform is a standalone skill with its own `SKILL.md`, invocable directly on any prompt-shaped content and composable by `/ForgeAdopt` during adoption. Initial vocabulary:
+
+- **`/DebrandPrompt`** — remove hardcoded vendor references; replace with category-level variables where the instruction generalizes
+- **`/MinimizePrompt`** — collapse motivational / marketing / filler prose while preserving directive content
+- **`/RescopePrompt`** — add or tighten `allowed-tools` frontmatter to the narrowest set the skill actually uses
+- **`/AlignPrompt`** — fix indentation, fence language tags, heading depth, and other convention mismatches
+- **`/ExtractPrompt`** — move bulk reference material into `@`-included companion files so the always-loaded content stays lean
+
+v1 note: these transform skills may not all exist at the first adoption. `/ForgeAdopt` v1 can embed transform logic inline while the vocabulary stabilizes; as a transform proves recurring, it extracts into its own skill and subsequent adoptions record it in `resolvedDependencies`. The schema in [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) supports both modes transparently.
+
+### What the mechanism does NOT do
+
+- No multi-metric gate is enforced in v1. The maintainer's judgment decides what ships. Gates ship later if Phase 2 evals produce a rubric worth encoding.
+- No automated submission to upstream catalogs. The skill's output is local artifacts; anything downstream of the repository is out of scope.
+- No parallel batch adoption. The skill runs once per invocation, produces one adoption, and stops. Serial by design.
+- No cache of upstream content. Every adoption fetches fresh; caching is a premature optimization while only 3-5 adoptions are planned.
+
+### Consequences
+
+- [+] Transforms are testable and evolvable independently; each transform skill can be invoked outside adoption (e.g., to debrand a forge-authored skill that accumulated branding over time)
+- [+] The build pipeline is explicit in provenance — every adopted skill records exactly which transform skill versions touched it, pinned by SHA
+- [+] Reuses existing primitives — skill schema, provenance sidecars, domain-scoped `skills/` directories, `@` companion includes — without inventing new structures
+- [+] Adopted skills integrate naturally with their domain; there is no visual "community vs first-party" split in the deployed tree
+- [-] The transform-skill vocabulary must be authored and maintained; each adds a small surface. Accepted — extraction is demand-driven, not speculative
+- [-] The maintainer must decide placement per adoption; the skill cannot default a destination, so judgment is required at every invocation. Accepted — the placement decision is part of the value
+
+## Related Decisions
+
+- [ARCH-0012](ARCH-0012 Community Adoption Strategy.md) — the strategic decision this mechanism implements
+- [ARCH-0001](ARCH-0001 Skills Agents and Rules.md) — the skill artifact class `/ForgeAdopt` and its transform skills belong to
+- [ARCH-0002](ARCH-0002 Skills Companion Files.md) — companion-file conventions used by `/ExtractPrompt` and adopted skills with extracted content
+- [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) — the sidecar schema that records transform skills as build dependencies
+- [CORE-0001](CORE-0001 Markdown as System Language.md) — the underlying principle that makes skill-first natural

--- a/docs/decisions/PROV-0006 Adoption Metadata in Provenance Sidecars.md
+++ b/docs/decisions/PROV-0006 Adoption Metadata in Provenance Sidecars.md
@@ -1,0 +1,137 @@
+---
+title: "Adoption Metadata in Provenance Sidecars"
+description: "Adoption reuses PROV-0003 with a distinct buildType; transform skills applied during adoption appear as SLSA resolvedDependencies, not local fields"
+type: adr
+category: architecture
+tags:
+    - provenance
+    - adoption
+    - schema
+status: accepted
+created: 2026-04-16
+updated: 2026-04-16
+author: "@N4M3Z"
+project: forge-core
+related:
+    - "PROV-0003 Provenance Tracking.md"
+    - "ARCH-0012 Community Adoption Strategy.md"
+    - "ARCH-0013 Markdown-First Adoption Mechanism.md"
+responsible: ["@N4M3Z"]
+accountable: ["@N4M3Z"]
+consulted: []
+informed: []
+upstream: []
+---
+
+# Adoption Metadata in Provenance Sidecars
+
+## Context and Problem Statement
+
+[ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md) decides that adopted community skills produce working `SKILL.md` artifacts and that each transform (debrand, minimize, rescope, align, extract) is itself a skill invoked as a build step. Each adoption therefore has two kinds of inputs: the upstream source being transformed, and the transform skills that touched it. Phase 2 of the strategy ([ARCH-0012](ARCH-0012 Community Adoption Strategy.md)) depends on this metadata being queryable across the corpus.
+
+[PROV-0003](PROV-0003 Provenance Tracking.md) already specifies `.provenance/<Name>.yaml` sidecars in [SLSA v1.0][SLSA] format for assembly builds. The question is how adoption fits into that schema — whether it needs local-forge fields under `externalParameters`, or whether SLSA's native `resolvedDependencies` already models the build composition exactly right.
+
+## Decision Drivers
+
+- [SLSA v1.0][SLSA]'s `resolvedDependencies` is designed to record every input that produced the artifact, including tooling — a transform skill applied during adoption is precisely an input in the SLSA sense
+- Recording transform skills as dependencies pins them by SHA, which means Phase 2 evals can answer "which version of `/MinimizePrompt` was applied to this adoption" without any forge-local schema
+- Duplicating the same data into a forge-local `transforms_applied` array would be redundant with `resolvedDependencies` and create two places to update
+- Git diffs and commit messages remain the lossless record of exactly what changed and why; structured dependency entries complement them, do not replace them
+
+## Considered Options
+
+1. **Reuse PROV-0003 unchanged, distinguish by `buildType` only, record transform skills as `resolvedDependencies`** — SLSA-native; transform versions pinned automatically; no forge-local schema.
+2. **Extend under `externalParameters` with a forge-local `transforms_applied` array** — categorization is queryable, but duplicates what `resolvedDependencies` already captures once transforms become skills.
+3. **Parallel sidecar** — `.adoption/<Name>.yaml` separate from PROV-0003. Two sidecars per artifact; no benefit.
+4. **Frontmatter carries everything** — machine-queryable via YAML parsing but assembly strips it at deploy, and it fights the CanonSidecar rule.
+
+## Decision Outcome
+
+Chosen option: **reuse PROV-0003 unchanged, distinguish by `buildType`, record transform skills as `resolvedDependencies`.**
+
+Because [ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md) defines each transform as a skill, the SLSA dependency model fits natively. Every transform skill applied to an adoption appears alongside the upstream source in `resolvedDependencies`, each pinned by SHA. No local-forge fields are needed; no parallel sidecar; no duplicate structures.
+
+### Schema
+
+```yaml
+predicate:
+    buildDefinition:
+        buildType: https://forge-cli/adopt/v1
+        externalParameters:
+            upstream_url: https://github.com/davila7/claude-code-templates/...
+        resolvedDependencies:
+            - name: upstream
+              uri: https://github.com/davila7/claude-code-templates/blob/<sha>/cli-tool/components/skills/security/security-best-practices/SKILL.md
+              digest:
+                  sha256: <upstream-sha>
+            - name: DebrandPrompt
+              uri: forge-core/skills/DebrandPrompt/SKILL.md
+              digest:
+                  sha256: <DebrandPrompt-sha>
+            - name: MinimizePrompt
+              uri: forge-core/skills/MinimizePrompt/SKILL.md
+              digest:
+                  sha256: <MinimizePrompt-sha>
+            - name: RescopePrompt
+              uri: forge-core/skills/RescopePrompt/SKILL.md
+              digest:
+                  sha256: <RescopePrompt-sha>
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.1.0
+            metadata:
+                startedOn: "2026-04-16T10:00:00Z"
+```
+
+### Field semantics
+
+All structural fields are [SLSA v1.0][SLSA] standards-defined:
+
+- **`buildType: https://forge-cli/adopt/v1`** — declares this is an adoption build. Distinguishes from assembly (`https://forge-cli/assemble/v1`). Phase 2 evals filter on this value.
+- **`externalParameters.upstream_url`** — convenience denormalization of the upstream dependency's URI for direct queryability without array traversal. `externalParameters` is SLSA's standards-sanctioned extension point; the schema is defined by `buildType`.
+- **`resolvedDependencies`** — every input that produced the artifact:
+    - `upstream` entry pins the source being transformed (URL + SHA).
+    - One entry per transform skill applied, pinned by its own `SKILL.md` SHA. The `uri` uses a module-relative path of the form `<module>/skills/<Name>/SKILL.md` so readers can resolve the dependency directly against the repository tree.
+- **`runDetails.metadata.startedOn`** — ISO-8601 timestamp of the adoption.
+
+### The v1 mode: inline transforms
+
+Before individual transform skills exist, `/ForgeAdopt` performs the transforms inline. In that mode, `resolvedDependencies` contains only the upstream entry; the fact that `buildType: https://forge-cli/adopt/v1` records an adoption and the diff shows what changed is sufficient. As transforms extract into skills ([ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md)), subsequent adoptions grow their dependency lists naturally. The schema supports both phases without change.
+
+### Where transform detail and rationale live
+
+The git diff between the adopted artifact and the upstream at the pinned SHA is the authoritative record of what changed. The commit message carries the prose reasoning — what was preserved, what was cut, why the destination was chosen, any non-obvious decisions. The sidecar's structured `resolvedDependencies` answers "which transform skills at what versions"; the diff answers "what text moved"; the commit answers "why." Three sources, no duplication.
+
+### Frontmatter contract for adopted skills
+
+The `SKILL.md` frontmatter gains exactly one field beyond the standard skill schema:
+
+- **`upstream`** (string, URL) — the permalink to the upstream source. No SHA suffix; the SHA lives in the sidecar's `resolvedDependencies`.
+
+All other adoption metadata is sidecar-only or git-native.
+
+### Consequences
+
+- [+] Pure SLSA: every structural concept used here is defined by the spec; no forge-local schema invention
+- [+] Transform skills are pinned by SHA in every adoption that used them — Phase 2 can answer "which version of `/MinimizePrompt` was applied" without inspecting forge's tooling version
+- [+] One source of truth per axis: structured dependencies in the sidecar, exact changes in the diff, prose rationale in the commit
+- [+] Extending from inline transforms to per-skill transforms requires zero schema change — `resolvedDependencies` just grows entries
+- [+] Assembly continues to strip frontmatter at deploy; adopted skills cost the same runtime tokens as any other skill
+- [-] A reader of the bare `SKILL.md` sees only `upstream:` and must open the sidecar for the dependency chain or run `git log` for rationale — mitigated by the fact that the adoption story is usually not what the reader needs when invoking the skill
+- [-] Cross-adoption queries ("how many adoptions applied `/MinimizePrompt`?") require YAML parsing of the `resolvedDependencies` arrays — straightforward but not a single-field scan
+
+## Related Decisions
+
+- [PROV-0003](PROV-0003 Provenance Tracking.md) — the base schema this ADR declares sufficient for adoption
+- [ARCH-0012](ARCH-0012 Community Adoption Strategy.md) — the strategy requiring Phase 2 eval queries across adopted skills
+- [ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md) — the mechanism producing the sidecars this ADR shapes; defines each transform as a skill
+
+## Links
+
+- [SLSA v1.0 Provenance][SLSA] — the upstream specification whose `resolvedDependencies` field natively models transform skills as build inputs
+- [in-toto Statement][INTOTO] — the envelope format that carries the SLSA predicate
+
+[SLSA]: https://slsa.dev/provenance/v1 "SLSA Provenance v1.0"
+[INTOTO]: https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md "in-toto Statement v1"

--- a/skills/AlignPrompt/SKILL.md
+++ b/skills/AlignPrompt/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: AlignPrompt
+description: "Fix indentation, fence language tags, heading depth, and frontmatter fields to match forge conventions. USE WHEN an adopted community skill or any prompt-shaped document fails a forge convention check (indent, fence, heading, schema)."
+version: 0.1.0
+allowed-tools: Read, Edit, Write
+---
+
+# AlignPrompt
+
+Bring a prompt-shaped document into forge convention without changing its meaning. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `align` transform.
+
+## What to fix
+
+| Axis              | Forge convention                                                               |
+| ----------------- | ------------------------------------------------------------------------------ |
+| Indentation       | Four spaces. No tabs. Applies to markdown, YAML, TOML, JSON, code blocks.      |
+| Fence tags        | Every fenced code block carries a language tag. Use `sh`, not `bash`.          |
+| Heading depth     | Max depth 3. No skipped levels (no H1 to H3 without H2 between).               |
+| Heading style     | One H1 per document, matching the skill name in PascalCase.                    |
+| Frontmatter keys  | `name`, `description`, `version`. Strip upstream fields forge does not use.    |
+| Skill name        | PascalCase, two words, scope plus focus (for example `SecurityBestPractices`). |
+| Table alignment   | Pipes line up vertically; pad cells with spaces to the widest column.          |
+| Trailing newline  | Every text file ends with a single `\n`.                                       |
+| Wikilinks / paths | Spaces literal, not URL-encoded.                                               |
+
+## What to preserve
+
+- The skill's actual instructions and workflow
+- Body structure and section order unless a heading level is wrong
+- Code block contents; only fix the fence tag, never the code inside
+- Emphasis and voice, except where convention conflicts
+
+## Procedure
+
+1. Read the full document.
+2. Fix frontmatter first — it gates downstream checks.
+3. Walk the heading tree, flagging any skip or over-deep section.
+4. Sweep indentation; convert tabs to four spaces.
+5. Sweep fences; ensure every one has a language tag.
+6. Align tables column by column.
+7. Re-read; the content meaning must be unchanged.
+
+## Constraints
+
+- Never rewrite content to fix alignment — only fix structure
+- If an upstream skill legitimately needs H4 or H5, flag it as a content issue, do not silently demote
+- Do not remove frontmatter fields the skill relies on for runtime behavior (`argument-hint`, `allowed-tools`, `hooks`)
+- If the H1 title does not match the skill name, rename the file or rewrite the H1 — do not leave them divergent

--- a/skills/DebrandPrompt/SKILL.md
+++ b/skills/DebrandPrompt/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: DebrandPrompt
+description: "Remove hardcoded vendor names, brand references, and external-service dependencies from a prompt-shaped document. USE WHEN an adopted skill hardcodes specific tool names, company brands, or paid service dependencies that would bias the skill toward one ecosystem."
+version: 0.1.0
+allowed-tools: Read, Edit, Grep
+---
+
+# DebrandPrompt
+
+Strip vendor and brand references from a prompt-shaped document so the skill generalizes across ecosystems. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `debrand` transform.
+
+## What to remove
+
+| Pattern                                      | Example                                                  | Replace with                                |
+| -------------------------------------------- | -------------------------------------------------------- | ------------------------------------------- |
+| Hardcoded vendor tool name in core guidance  | "Use Docker Scout for vulnerability scanning"            | "Use a vulnerability scanner"               |
+| "Powered by X" or partner-credit language    | "Built on top of Supabase"                               | Remove                                      |
+| External-service dependency as mandatory     | "Configure Kong as the API gateway"                      | "Configure an API gateway"                  |
+| Specific author attribution in body          | "The codex team recommends..."                           | Remove attribution, keep the recommendation |
+| Marketing affiliate language                 | "With built-in Auth0 integration"                        | "With authentication integration"           |
+| First-person voice tied to a specific org    | "Our team uses X"                                        | Describe the pattern, not the org           |
+
+## What to preserve
+
+- Vendor names that appear in **anti-pattern citations**: "avoid Inter, Roboto, Arial" stays — the names are the signal
+- Vendor names that identify a standard (HTTP, OAuth, SAML, TLS) — these are protocol names, not brands
+- Commands and package names in code blocks when they are the actual invocation the user needs
+- License attributions in frontmatter or companion files
+
+## The anti-pattern test
+
+Ask: if I replaced this vendor name with `<category>`, does the sentence still convey the instruction?
+
+- "Use Docker Scout" → "Use a vulnerability scanner" — passes, debrand it
+- "Avoid Inter and Roboto" → "Avoid <font>s and <font>s" — fails, keep the names because they ARE the content
+
+## Procedure
+
+1. Grep for common vendor markers: capitalized product names, `@` handles, URLs pointing to non-standard services.
+2. For each match, apply the anti-pattern test.
+3. When removing, replace with the category (scanner, gateway, font, service) — do not delete in place.
+4. Update `allowed-tools` if a removed vendor tool implied a tool grant.
+5. Re-read; the skill should read as ecosystem-neutral where appropriate.
+
+## Constraints
+
+- Never remove vendor names from anti-pattern lists — they are the directive
+- Do not neutralize protocol names (HTTP, TLS, OAuth) — these are universal
+- If the skill is explicitly about a specific vendor (for example, a Fakturoid skill), do not debrand — the vendor is the scope
+- When in doubt between debranding and preserving, preserve and flag for review

--- a/skills/ExtractPrompt/SKILL.md
+++ b/skills/ExtractPrompt/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ExtractPrompt
+description: "Move bulk reference material from the main SKILL.md body into @-included companion files so the always-loaded content stays lean. USE WHEN an adopted or authored skill's body exceeds its information density because it inlines reference tables, pricing, catalogs, or per-variant guidance."
+version: 0.1.0
+allowed-tools: Read, Edit, Write
+---
+
+# ExtractPrompt
+
+Move bulk reference material out of `SKILL.md` into companion files referenced with `@` includes. The SKILL.md stays the entrypoint an AI reads to decide behavior; companions load on demand when the AI needs the reference data. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `extract` transform.
+
+Follows [ARCH-0002](docs/decisions/ARCH-0002 Skills Companion Files.md).
+
+## What to extract
+
+| Content shape                                                              | Extract to a companion?            |
+| -------------------------------------------------------------------------- | ---------------------------------- |
+| Long reference table (model pricing, language-specific rules, catalogs)    | Yes                                |
+| Per-variant guidance (one section per framework, language, or ecosystem)    | Yes, one companion per variant     |
+| Command reference (many commands, each with flags and examples)             | Yes, if it spans more than a screen |
+| Full example project                                                        | Yes, always                        |
+| Workflow that decides HOW to use the skill                                  | No, stays in `SKILL.md`            |
+| Constraints, red flags, anti-patterns                                       | No, stays in `SKILL.md`            |
+| Decision tables with 3-7 rows                                               | No, inline                         |
+
+## Procedure
+
+1. Identify candidate sections — content that is reference material rather than instruction.
+2. For each candidate, move it to a companion file named by its scope (`PythonReference.md`, `Tables.md`, `ModelPricing.md`).
+3. Replace the extracted block with an `@` include in `SKILL.md`:
+
+    ```markdown
+    ## Language-specific guidance
+
+    @python-security.md
+    @typescript-security.md
+    @go-security.md
+    ```
+
+4. Keep the section heading in `SKILL.md` so the AI knows the companion exists.
+5. Re-read `SKILL.md` alone. It should still be a complete instruction — the AI must be able to decide what to do without loading the companion.
+
+## Naming
+
+- Companions live in the same directory as `SKILL.md`
+- PascalCase for conceptual companions (`TemplateReference.md`, `SchemaValidation.md`)
+- kebab-case for variant-keyed companions (`python-django-security.md`)
+- One companion per topic; do not bundle unrelated reference material
+
+## Constraints
+
+- `SKILL.md` must remain complete as instruction on its own — companions are reference, not required loading
+- Never extract decision-making content; the AI needs it to choose which companion to read
+- Do not create a companion unless at least 200 words would move; smaller moves are just fragmentation
+- Keep companion files under 2000 words each; split further if they grow
+- Do not nest companions (a companion cannot `@`-include another companion) — compose at the SKILL.md level

--- a/skills/ForgeAdopt/SKILL.md
+++ b/skills/ForgeAdopt/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: ForgeAdopt
+description: "Adopt a community skill from an upstream URL into forge. Fetches the source, applies transforms, produces a working SKILL.md with SLSA provenance. USE WHEN adopting a community skill from aitmpl, anthropics/skills, or a similar catalog."
+version: 0.1.0
+argument-hint: <upstream-url>
+allowed-tools: Bash, WebFetch, Read, Write, Edit, Grep, Glob
+---
+
+# ForgeAdopt
+
+Orchestrating workflow for adopting a community skill into forge. Produces a first-class `SKILL.md` with a SLSA provenance sidecar, following the strategy in [ARCH-0012](docs/decisions/ARCH-0012 Community Adoption Strategy.md) and the mechanism in [ARCH-0013](docs/decisions/ARCH-0013 Markdown-First Adoption Mechanism.md).
+
+## Workflow
+
+### 1. Fetch and pin
+
+Accept an upstream URL. Resolve its commit SHA and fetch content at that commit:
+
+```sh
+# For GitHub sources
+gh api "repos/<owner>/<repo>/commits?path=<path>&per_page=1" --jq '.[0].sha'
+curl -sSL "https://raw.githubusercontent.com/<owner>/<repo>/<sha>/<path>" -o /tmp/claude/upstream-<slug>.md
+shasum -a 256 /tmp/claude/upstream-<slug>.md
+```
+
+Record: commit SHA, commit-pinned permalink, content SHA-256.
+
+### 2. Read and decide
+
+Read the upstream file. Apply [ARCH-0012](docs/decisions/ARCH-0012 Community Adoption Strategy.md)'s selection rules:
+
+| Check | Reject if... |
+|-------|--------------|
+| Artifact class | It's a rule or an agent, not a skill |
+| Name collision | An existing first-party forge skill has the same name |
+| Duplication | It duplicates a forge skill without demonstrable delta |
+| Use intent | The maintainer won't actually invoke it |
+| Placement | No existing module is a natural domain home |
+
+Pick the destination module. If nothing fits, defer the adoption; do not create a new module to house a single imported skill.
+
+### 3. Apply transforms
+
+Transforms are named operations that will extract into their own skills as patterns stabilize. In v1 they run inline:
+
+| Transform  | What it does                                                                                                |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| `align`    | Rename to PascalCase; fix indent, fence language tags, heading depth; strip upstream frontmatter fields forge doesn't use |
+| `rescope`  | Add or tighten `allowed-tools` to the narrowest set the skill actually uses                                 |
+| `debrand`  | Remove hardcoded vendor references (specific tool names, external services, "powered by X" language)        |
+| `minimize`   | Collapse motivational or marketing prose while preserving directive content                                 |
+| `extract`  | Move bulk reference material into `@`-included companion files so the always-loaded `SKILL.md` stays lean   |
+
+Record which transforms were applied; it guides the commit message and is what future transform-skill dependencies will represent in the sidecar.
+
+### 4. Add forge frontmatter
+
+Minimum adopted-skill frontmatter:
+
+```yaml
+---
+name: <PascalCaseName>
+description: "<one sentence>. USE WHEN <trigger>. Not for <anti-trigger>."
+version: 0.1.0
+allowed-tools: <comma-separated narrow list>
+upstream: <url-to-main-branch-file>
+---
+```
+
+The `upstream` field is a human-facing pointer without SHA ([PROV-0006](docs/decisions/PROV-0006 Adoption Metadata in Provenance Sidecars.md)); the SHA pin lives in the sidecar.
+
+### 5. Write the artifact
+
+Land at `skills/<PascalCaseName>/SKILL.md` in the destination module. Compute its SHA-256 after writing:
+
+```sh
+shasum -a 256 skills/<PascalCaseName>/SKILL.md
+```
+
+### 6. Write the provenance sidecar
+
+Land at `skills/<PascalCaseName>/.provenance/SKILL.yaml`:
+
+```yaml
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: skills/<Name>/SKILL.md
+          digest:
+              sha256: <adopted-sha256>
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://forge-cli/adopt/v1
+            externalParameters:
+                upstream_url: <commit-pinned-url>
+            resolvedDependencies:
+                - name: upstream
+                  uri: <commit-pinned-url>
+                  digest:
+                      sha256: <upstream-sha256>
+                - name: ForgeAdopt
+                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                  digest:
+                      sha256: <ForgeAdopt-sha256>
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: <version>
+            metadata:
+                startedOn: <iso-8601>
+```
+
+Every adoption records `ForgeAdopt` itself as a dependency — the orchestrator is a build input. When individual transform skills extract (`DebrandPrompt`, `MinimizePrompt`, etc.), each applied transform adds its own entry under `resolvedDependencies`.
+
+### 7. Commit
+
+One commit per adoption. Commit message carries the prose rationale — what was preserved, what was cut, why the destination was chosen, which transforms fired. Rationale lives here, not in the sidecar ([PROV-0006](docs/decisions/PROV-0006 Adoption Metadata in Provenance Sidecars.md)).
+
+## Constraints
+
+- Skills only — rules and agents are excluded from adoption ([ARCH-0012](docs/decisions/ARCH-0012 Community Adoption Strategy.md))
+- First-party forge skills take precedence on name conflicts; rename the adoption or reject it
+- Every adoption writes a provenance sidecar; an adoption without provenance is not an adoption
+- Defer the adoption if no existing module is a natural home; do not create new modules for one skill
+- Adopt at most 3-5 skills in the initial phase — selectivity is the point

--- a/skills/MinimizePrompt/SKILL.md
+++ b/skills/MinimizePrompt/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: MinimizePrompt
+description: "Remove motivational, marketing, and filler prose from a prompt-shaped document while preserving directive content. USE WHEN adopting a community skill, authoring a skill or rule that feels bloated, or auditing an existing artifact for token waste. Applies MVPR principles."
+version: 0.1.0
+allowed-tools: Read, Edit, Write
+---
+
+# MinimizePrompt
+
+Cut motivational, marketing, and emphasis-inflated prose from prompt-shaped documents. Preserve the directive content and the facts that make the artifact work.
+
+Aligned with [MVPR-0001](docs/decisions/MVPR-0001 Minimum Viable Prompt.md) and [MVPR-0002](docs/decisions/MVPR-0002 Prompt Minimalization Metrics.md). Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `minimize` transform.
+
+## What to remove
+
+| Pattern                   | Example                                                                |
+| ------------------------- | ---------------------------------------------------------------------- |
+| Motivational framing      | "Don't hold back", "Claude is capable of extraordinary work"           |
+| Emphasis inflation        | CAPS-LOCKED warnings, repeated `**CRITICAL**` or `**IMPORTANT**`       |
+| Marketing superlatives    | "Production-ready", "Best-in-class", "Complete toolkit"                |
+| Filler transitions        | "First of all", "It's worth noting", "As previously mentioned"         |
+| Tautology                 | "Use good practices" without defining good practices                   |
+| Duplicate summaries       | Opening paragraph repeats the description; closing repeats the opening |
+| Decorative checkmarks     | ✅-bulleted feature lists that restate workflow content                 |
+
+## What to preserve
+
+- Workflow steps and decision points
+- Anti-patterns with concrete examples ("avoid X because Y")
+- Tables, code blocks, and command examples
+- Constraints and hard rules
+- Frontmatter fields that affect routing — `description`, `allowed-tools`, `name`, `version`
+
+## Red flags that a section should stay
+
+A section earns its tokens if it does at least one of:
+
+- Cites a specific source, rule, benchmark, or prior decision
+- Names a concrete anti-pattern with a reason
+- Is referenced by another section in the same document
+- Carries a command, regex, schema, or structured data
+- Encodes a decision that cannot be reconstructed from names alone
+
+If none of the above applies, the section is a candidate for removal.
+
+## Procedure
+
+1. Read the document end-to-end once before cutting.
+2. Identify the load-bearing sections — workflow, constraints, examples, tables. These are immune.
+3. Sweep the remaining prose for the patterns in "What to remove." Cut per-pattern, not per-paragraph.
+4. After each sweep, re-read. If a sentence no longer makes sense without a neighbor, the cut was too aggressive.
+5. Measure the delta. A healthy minimization on a community prompt cuts 20-40% of tokens. More than 50% suggests content loss, not just filler loss.
+
+## Constraints
+
+- Never remove content that names a specific failure mode
+- Never collapse a table or code block into prose
+- Preserve anti-pattern lists even if worded emphatically — the emphasis is directive signal, not filler
+- Keep one concrete example per abstract principle; cut additional restatements
+- Do not rewrite in a different voice; remove, do not paraphrase

--- a/skills/RescopePrompt/SKILL.md
+++ b/skills/RescopePrompt/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: RescopePrompt
+description: "Tighten a prompt-shaped document's tool scope to the narrowest set it actually uses. USE WHEN an adopted or authored skill declares allowed-tools: '*', omits the frontmatter field entirely, or grants tools the workflow never invokes."
+version: 0.1.0
+allowed-tools: Read, Edit, Grep
+---
+
+# RescopePrompt
+
+Narrow a skill's `allowed-tools` frontmatter to the tools the workflow actually invokes. Implicit `"*"` and undeclared scope are treated as bugs. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `rescope` transform.
+
+## What to narrow
+
+- `allowed-tools: "*"` — treat as declaration of intent, not trust; enumerate explicitly
+- Missing `allowed-tools` — add the field with the narrowest set the skill needs
+- Overbroad grants (for example `Bash` when the skill only reads files) — strip
+- Comma-separated strings with trailing whitespace, duplicates, or inconsistent casing — normalize
+
+## Procedure
+
+1. Read the skill body end-to-end.
+2. Identify every tool the workflow invokes. Watch for indirect invocation (a Bash command calling a tool the skill uses).
+3. Start from zero. Add only the tools the workflow actually uses.
+4. Prefer read-only scope (`Read`, `Grep`, `Glob`) over write or exec when the workflow allows.
+5. If the skill invokes shell commands, grant `Bash` but note the expected command family in a comment or the description.
+6. Write the result as a comma-separated list in the frontmatter.
+
+## Evidence required per tool
+
+| Tool   | Grant only if the skill…                             |
+| ------ | ---------------------------------------------------- |
+| Read   | reads a file                                         |
+| Grep   | searches file contents                               |
+| Glob   | enumerates file paths                                |
+| Edit   | modifies an existing file                            |
+| Write  | creates or overwrites a file                         |
+| Bash   | invokes shell commands                               |
+| Skill  | composes other skills as build steps                 |
+| WebFetch | retrieves remote content over HTTP                 |
+
+## Constraints
+
+- Never grant `Bash` on speculation — find the command the skill runs
+- `*` is never an acceptable final value; if the skill genuinely needs everything, the skill is doing too much
+- Do not grant tools to "future-proof" the skill — add them when the workflow adds them
+- Document unusual grants in the skill body when the reason isn't obvious from the workflow


### PR DESCRIPTION
## Summary

Introduces the markdown-first, skill-first mechanism for adopting community skills from catalogs such as [aitmpl.com](https://www.aitmpl.com) into forge.

**ADRs:**

- [ARCH-0012 Community Adoption Strategy](docs/decisions/ARCH-0012%20Community%20Adoption%20Strategy.md) — positioning, scope, and inclusion/exclusion rules. Selective extraction; curator, not aggregator; competitive framing dropped.
- [ARCH-0013 Markdown-First Adoption Mechanism](docs/decisions/ARCH-0013%20Markdown-First%20Adoption%20Mechanism.md) — the workflow-skill approach composing per-transform skills as build steps.
- [PROV-0006 Adoption Metadata in Provenance Sidecars](docs/decisions/PROV-0006%20Adoption%20Metadata%20in%20Provenance%20Sidecars.md) — extends [PROV-0003](docs/decisions/PROV-0003%20Provenance%20Tracking.md) with a distinct \`buildType\` and records transform skills as \`resolvedDependencies\`. Rationale lives in commit messages, not the sidecar.

**Skills:**

- \`skills/ForgeAdopt\` — orchestrating workflow that fetches, transforms, and produces \`SKILL.md\` + provenance sidecar.
- \`skills/AlignPrompt\`, \`DebrandPrompt\`, \`MinimizePrompt\`, \`RescopePrompt\`, \`ExtractPrompt\` — transform skills composable by \`ForgeAdopt\` during adoption; each is independently invokable.

Phase 4 (publishing pipeline / verified marketplace) is explicitly deleted under the dropped competitive framing. If productization ever becomes interesting, a new plan will be written from the artifacts accumulated.

## Test plan

- [x] \`forge validate .\` passes after the pipeline commit (pre-commit hook ran successfully)
- [x] All seven skills pass the forge skill \`.mdschema\`
- [x] All three ADRs pass the forge ADR \`.mdschema\` + \`templates/forge-adr.json\`
- [ ] CI passes on this PR