### PR TITLE
feat: adopt three skills from aitmpl.com

### DIFF
--- a/skills/FrontendDesign/.provenance/SKILL.yaml
+++ b/skills/FrontendDesign/.provenance/SKILL.yaml
@@ -1,0 +1,40 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: skills/FrontendDesign/SKILL.md
+          digest:
+              sha256: a0533daaf6235789b6dbdbbdcc14632eb372b1920bd37ced37fa07719fe35d31
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://forge-cli/adopt/v1
+            externalParameters:
+                upstream_url: https://github.com/davila7/claude-code-templates/blob/1deb97c72161528f6b7d84bc5117ae4be2e42735/cli-tool/components/skills/creative-design/frontend-design/SKILL.md
+            resolvedDependencies:
+                - name: upstream
+                  uri: https://github.com/davila7/claude-code-templates/blob/1deb97c72161528f6b7d84bc5117ae4be2e42735/cli-tool/components/skills/creative-design/frontend-design/SKILL.md
+                  digest:
+                      sha256: b81e2ff87ed8fa4d6c377ccb127a7254c9e6a77e3ae94f21e6b514f7bb2945a0
+                - name: ForgeAdopt
+                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                  digest:
+                      sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
+                - name: AlignPrompt
+                  uri: forge-core/skills/AlignPrompt/SKILL.md
+                  digest:
+                      sha256: 1f16a4bd57021cd7802ac1e99975811dd2a749960e5898ebdab50f570bd75f90
+                - name: RescopePrompt
+                  uri: forge-core/skills/RescopePrompt/SKILL.md
+                  digest:
+                      sha256: f9219dd6a0b47d8ffd6aceb2b9e3c3835fe7f7f022c0448d60fb8519322431cd
+                - name: MinimizePrompt
+                  uri: forge-core/skills/MinimizePrompt/SKILL.md
+                  digest:
+                      sha256: 09cc1baa8e0e25d0514dba717008df249f4ad07ff54b3a318839f69df9a47794
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.1.0
+            metadata:
+                startedOn: "2026-04-17T00:30:00Z"

--- a/skills/FrontendDesign/SKILL.md
+++ b/skills/FrontendDesign/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: FrontendDesign
+description: "Build distinctive, production-grade frontend interfaces that avoid generic AI aesthetics. USE WHEN the user asks for web components, pages, landing pages, dashboards, React / HTML / CSS layouts, or styling of any web UI. Not for backend or non-UI work."
+version: 0.1.0
+allowed-tools: Read, Grep, Write, Edit
+upstream: https://github.com/davila7/claude-code-templates/blob/main/cli-tool/components/skills/creative-design/frontend-design/SKILL.md
+---
+
+# FrontendDesign
+
+Create distinctive, production-grade web interfaces. Commit to an aesthetic direction and execute with precision — intentionality wins over intensity, whether the direction is bold maximalism or refined minimalism.
+
+## Direction
+
+Before coding, decide on a clear aesthetic direction. Pick one and stay true to it:
+
+- Brutally minimal, maximalist chaos, retro-futuristic, organic, luxury, playful, editorial, brutalist, art deco, pastel, industrial — or a point of your own choosing.
+
+Name the context, the audience, and the one thing someone will remember about the result.
+
+## Aesthetics
+
+| Axis        | Guidance                                                                                                         |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| Typography  | Distinctive, characterful choices. Pair a display font with a refined body font. Avoid generic system fonts.      |
+| Color       | Dominant colors with sharp accents outperform evenly distributed palettes. Use CSS variables for consistency.     |
+| Motion      | High-impact moments over scattered interactions. One orchestrated page load beats many micro-interactions.        |
+| Layout      | Asymmetry, overlap, diagonal flow, grid-breaking. Generous negative space OR controlled density — commit.         |
+| Atmosphere  | Gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, grain overlays.    |
+
+Match implementation complexity to the vision: maximalist designs get elaborate animations and effects; minimalist designs demand restraint, precision, and attention to spacing and detail.
+
+## Avoid
+
+- Overused font families (Inter, Roboto, Arial, system fonts, Space Grotesk — don't converge on "safe" choices across generations)
+- Cliched color schemes (purple gradients on white is the canonical offender)
+- Predictable layouts and component patterns
+- Cookie-cutter design that lacks context-specific character
+
+## Vary
+
+No two designs should be the same. Vary themes (light/dark), fonts, aesthetics across generations. If the last output used a display serif and a teal-on-ink palette, the next should not.
+
+## Constraints
+
+- Produce real, working code — HTML/CSS/JS, React, Vue, etc. — not mockups
+- Maintain a single aesthetic point-of-view across the whole output; do not mix brutalist typography with pastel gradients
+- Accessibility and performance are not aesthetic concessions; they are part of production-grade

--- a/skills/SecurityBestPractices/.provenance/SKILL.yaml
+++ b/skills/SecurityBestPractices/.provenance/SKILL.yaml
@@ -1,0 +1,44 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: skills/SecurityBestPractices/SKILL.md
+          digest:
+              sha256: 59e7ac3a651c86137eadb761aa50b53d2b3196c159ff56fa5ffaacff15aa5c40
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://forge-cli/adopt/v1
+            externalParameters:
+                upstream_url: https://github.com/davila7/claude-code-templates/blob/72b67369cb085cb416a8bf85b747450a0d716e33/cli-tool/components/skills/security/security-best-practices/SKILL.md
+            resolvedDependencies:
+                - name: upstream
+                  uri: https://github.com/davila7/claude-code-templates/blob/72b67369cb085cb416a8bf85b747450a0d716e33/cli-tool/components/skills/security/security-best-practices/SKILL.md
+                  digest:
+                      sha256: 93222336cbb0e6745f95ce8ca0e2095f7fcdc7fb062d8e4cf0ecb38fa01fe75b
+                - name: ForgeAdopt
+                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                  digest:
+                      sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
+                - name: AlignPrompt
+                  uri: forge-core/skills/AlignPrompt/SKILL.md
+                  digest:
+                      sha256: 1f16a4bd57021cd7802ac1e99975811dd2a749960e5898ebdab50f570bd75f90
+                - name: RescopePrompt
+                  uri: forge-core/skills/RescopePrompt/SKILL.md
+                  digest:
+                      sha256: f9219dd6a0b47d8ffd6aceb2b9e3c3835fe7f7f022c0448d60fb8519322431cd
+                - name: DebrandPrompt
+                  uri: forge-core/skills/DebrandPrompt/SKILL.md
+                  digest:
+                      sha256: ff0c248906d89d94be5b7a8a75453d796e72fe9d8698162eaaaaca905eaef016
+                - name: MinimizePrompt
+                  uri: forge-core/skills/MinimizePrompt/SKILL.md
+                  digest:
+                      sha256: 09cc1baa8e0e25d0514dba717008df249f4ad07ff54b3a318839f69df9a47794
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.1.0
+            metadata:
+                startedOn: "2026-04-17T00:00:00Z"

--- a/skills/SecurityBestPractices/SKILL.md
+++ b/skills/SecurityBestPractices/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: SecurityBestPractices
+description: "Language and framework specific security reviews for python, javascript/typescript, and go. USE WHEN the user requests a security review, secure-by-default coding help, or a vulnerability report. Not for general code review or debugging."
+version: 0.1.0
+allowed-tools: Read, Grep, Glob, Write
+upstream: https://github.com/davila7/claude-code-templates/blob/main/cli-tool/components/skills/security/security-best-practices/SKILL.md
+---
+
+# SecurityBestPractices
+
+Language and framework specific security best practices — secure-by-default coding, passive detection, or a full vulnerability report.
+
+## Scope
+
+Triggers only for python, javascript/typescript, and go. For other languages, rely on general knowledge and flag that concrete guidance is not available.
+
+## Workflow
+
+1. **Identify** the languages and frameworks in use — frontend and backend separately for web apps. Focus on the primary core frameworks.
+2. **Load guidance** — if this skill's `references/` directory contains `<language>-<framework>-<stack>-security.md` or a general `<language>-general-<stack>-security.md`, read all matching files. Web apps need both frontend and backend references.
+3. **Operate in one of three modes**:
+
+| Mode                    | Trigger                                     | Behavior                                                          |
+| ----------------------- | ------------------------------------------- | ----------------------------------------------------------------- |
+| Write secure-by-default | Starting new project or writing new code    | Apply guidance proactively                                        |
+| Passively detect        | Working in an existing project              | Flag critical findings to the user inline                         |
+| Full report             | User explicitly requests it                 | Write `security_best_practices_report.md` with prioritized issues |
+
+If no references exist for the stack, note that concrete guidance is unavailable but still perform the action based on general security knowledge.
+
+## Overrides
+
+Project-level documentation may require bypassing specific best practices. When overriding, report the override to the user without arguing. Suggest adding a note to project docs explaining the reason so the bypass is visible to future work.
+
+## Report Format
+
+- Write to `security_best_practices_report.md` unless the user specifies another path
+- Short executive summary at top
+- Delineated sections by severity; focus on critical findings
+- Number findings with a numeric ID for cross-reference
+- For critical findings, include a one-sentence impact statement
+- When referencing code, include file paths and line numbers
+- After writing the file, summarize findings and point to the report location
+
+## Fixes
+
+Apply fixes one finding at a time. Add concise comments in the code pointing to the specific best practice. Consider regressions — insecure code often survives because it's load-bearing; break things and the user will reject future fixes.
+
+Follow the project's commit and testing conventions. Commit messages should reference the security best practice being aligned to. Avoid bundling unrelated findings.
+
+## General Advice
+
+### Avoid incrementing IDs for publicly exposed resources
+
+Use UUID4 or random hex strings instead of small auto-incrementing integers. Prevents enumeration attacks and resource-count inference.
+
+### TLS and secure cookies
+
+Do not report missing TLS as a security issue — dev environments rarely have TLS or use an out-of-scope proxy. Set `Secure` on cookies only when the app is actually over TLS; otherwise local dev and testing break. Provide an env flag to gate `Secure`. Avoid recommending HSTS — its lasting impact (including major user lockouts) requires deep understanding.
+
+## Constraints
+
+- Trigger only on explicit security-review requests, never on generic code review or debugging
+- Do not argue with project-level overrides; document them instead
+- Report dev-only TLS gaps as best-practice notes, not vulnerabilities

--- a/skills/SkillDiscipline/.provenance/SKILL.yaml
+++ b/skills/SkillDiscipline/.provenance/SKILL.yaml
@@ -3,7 +3,7 @@ provenance:
     subject:
         - name: skills/SkillDiscipline/SKILL.md
           digest:
-              sha256: a68ea2edb8b65478b4ed30147f5652dfa2d9c3b6f0f1b9cf8a19731fb6593711
+              sha256: e4279a289b9db52cdda1945a69c4c534650ddedce9977969c6ce0ffeea599c80
     predicateType: https://slsa.dev/provenance/v1
     predicate:
         buildDefinition:

--- a/skills/SkillDiscipline/.provenance/SKILL.yaml
+++ b/skills/SkillDiscipline/.provenance/SKILL.yaml
@@ -1,0 +1,44 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: skills/SkillDiscipline/SKILL.md
+          digest:
+              sha256: a68ea2edb8b65478b4ed30147f5652dfa2d9c3b6f0f1b9cf8a19731fb6593711
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://forge-cli/adopt/v1
+            externalParameters:
+                upstream_url: https://github.com/davila7/claude-code-templates/blob/af0b99278d2f8b705bdf700f19c3125c05de7ede/cli-tool/components/skills/development/using-superpowers/SKILL.md
+            resolvedDependencies:
+                - name: upstream
+                  uri: https://github.com/davila7/claude-code-templates/blob/af0b99278d2f8b705bdf700f19c3125c05de7ede/cli-tool/components/skills/development/using-superpowers/SKILL.md
+                  digest:
+                      sha256: 6a4a4159bf8f784672460f0ec438d4f87adecd54413fdde7e5f0fe66eea3855e
+                - name: ForgeAdopt
+                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                  digest:
+                      sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
+                - name: AlignPrompt
+                  uri: forge-core/skills/AlignPrompt/SKILL.md
+                  digest:
+                      sha256: 1f16a4bd57021cd7802ac1e99975811dd2a749960e5898ebdab50f570bd75f90
+                - name: RescopePrompt
+                  uri: forge-core/skills/RescopePrompt/SKILL.md
+                  digest:
+                      sha256: f9219dd6a0b47d8ffd6aceb2b9e3c3835fe7f7f022c0448d60fb8519322431cd
+                - name: DebrandPrompt
+                  uri: forge-core/skills/DebrandPrompt/SKILL.md
+                  digest:
+                      sha256: ff0c248906d89d94be5b7a8a75453d796e72fe9d8698162eaaaaca905eaef016
+                - name: MinimizePrompt
+                  uri: forge-core/skills/MinimizePrompt/SKILL.md
+                  digest:
+                      sha256: 09cc1baa8e0e25d0514dba717008df249f4ad07ff54b3a318839f69df9a47794
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.1.0
+            metadata:
+                startedOn: "2026-04-17T00:35:00Z"

--- a/skills/SkillDiscipline/SKILL.md
+++ b/skills/SkillDiscipline/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: SkillDiscipline
+description: "Check for relevant skills before responding to a user message, including before clarifying questions. USE WHEN you are about to reply and have not verified whether a skill applies. Applies universally."
+version: 0.1.0
+allowed-tools: Skill
+upstream: https://github.com/davila7/claude-code-templates/blob/main/cli-tool/components/skills/development/using-superpowers/SKILL.md
+---
+
+# SkillDiscipline
+
+Check for skills before any response, including clarifying questions. If there is even a one-in-a-hundred chance a skill applies, invoke the Skill tool first.
+
+## The Rule
+
+Before responding to a user message:
+
+1. Identify what the user is asking for — including clarifying questions, exploration, or apparently trivial answers.
+2. Ask "does any skill match this intent?" If plausibly yes, invoke the Skill tool before drafting a reply.
+3. Announce which skill you're using and why.
+4. Follow the skill as written. If the skill has a checklist, convert each item into a task before proceeding.
+
+## Flow
+
+```dot
+digraph skill_flow {
+    "user message" [shape=doublecircle];
+    "any skill apply?" [shape=diamond];
+    "invoke Skill" [shape=box];
+    "announce usage" [shape=box];
+    "has checklist?" [shape=diamond];
+    "create tasks per item" [shape=box];
+    "follow skill" [shape=box];
+    "respond" [shape=doublecircle];
+
+    "user message" -> "any skill apply?";
+    "any skill apply?" -> "invoke Skill" [label="yes, even 1%"];
+    "any skill apply?" -> "respond" [label="definitely not"];
+    "invoke Skill" -> "announce usage";
+    "announce usage" -> "has checklist?";
+    "has checklist?" -> "create tasks per item" [label="yes"];
+    "has checklist?" -> "follow skill" [label="no"];
+    "create tasks per item" -> "follow skill";
+    "follow skill" -> "respond";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP — you are rationalizing your way out of a skill check:
+
+| Thought                                 | Reality                                                   |
+| --------------------------------------- | --------------------------------------------------------- |
+| "This is just a simple question"        | Questions are tasks. Check for skills.                    |
+| "I need more context first"             | Skill check comes BEFORE clarifying questions.            |
+| "Let me explore the codebase first"     | Skills tell you HOW to explore. Check first.              |
+| "I can check git or files quickly"      | Files lack conversation context. Check for skills.        |
+| "Let me gather information first"       | Skills tell you HOW to gather information.                |
+| "This doesn't need a formal skill"      | If a skill exists, use it.                                |
+| "I remember this skill"                 | Skills evolve. Read the current version.                  |
+| "This doesn't count as a task"          | Action is a task. Check for skills.                       |
+| "The skill is overkill"                 | Simple tasks become complex. Use it.                      |
+| "I'll just do this one thing first"     | Check before doing anything.                              |
+| "This feels productive"                 | Undisciplined action wastes time. Skills prevent this.    |
+
+## Priority When Multiple Skills Apply
+
+1. **Process skills first** — brainstorming, debugging, planning. These decide HOW to approach the task.
+2. **Implementation skills second** — domain-specific skills. These guide execution.
+
+"Let's build X" → process skill (brainstorming), then implementation.
+"Fix this bug" → process skill (debugging), then domain-specific.
+
+## Skill Types
+
+- **Rigid** (for example, test-driven development, debugging flows) — follow exactly. Do not adapt away discipline.
+- **Flexible** (patterns) — adapt principles to context.
+
+The skill itself tells you which kind it is.
+
+## Constraints
+
+- Skill check precedes the first token of any response, including clarifying questions
+- User instructions say WHAT, not HOW; a direct instruction does not authorize skipping a workflow
+- If the Skill tool finds nothing that plausibly matches, proceed directly to the response — do not invent a skill

--- a/skills/SkillDiscipline/SKILL.md
+++ b/skills/SkillDiscipline/SKILL.md
@@ -21,28 +21,16 @@ Before responding to a user message:
 
 ## Flow
 
-```dot
-digraph skill_flow {
-    "user message" [shape=doublecircle];
-    "any skill apply?" [shape=diamond];
-    "invoke Skill" [shape=box];
-    "announce usage" [shape=box];
-    "has checklist?" [shape=diamond];
-    "create tasks per item" [shape=box];
-    "follow skill" [shape=box];
-    "respond" [shape=doublecircle];
+For every incoming user message:
 
-    "user message" -> "any skill apply?";
-    "any skill apply?" -> "invoke Skill" [label="yes, even 1%"];
-    "any skill apply?" -> "respond" [label="definitely not"];
-    "invoke Skill" -> "announce usage";
-    "announce usage" -> "has checklist?";
-    "has checklist?" -> "create tasks per item" [label="yes"];
-    "has checklist?" -> "follow skill" [label="no"];
-    "create tasks per item" -> "follow skill";
-    "follow skill" -> "respond";
-}
-```
+1. Read the message and identify intent — including clarifying questions, exploration, or apparently trivial answers.
+2. Ask "does any skill plausibly match this intent?"
+    - If definitely no, respond directly.
+    - If there is even a 1% chance yes, invoke the Skill tool first.
+3. Announce which skill was chosen and why.
+4. If the skill has a checklist, convert each item into a task before proceeding.
+5. Follow the skill as written.
+6. Respond.
 
 ## Red Flags
 


### PR DESCRIPTION
## Summary

First batch of community adoptions via \`/ForgeAdopt\` under the pipeline introduced in #18.

- **SecurityBestPractices** — adopted from aitmpl's [\`security-best-practices\`](https://github.com/davila7/claude-code-templates/blob/72b67369cb085cb416a8bf85b747450a0d716e33/cli-tool/components/skills/security/security-best-practices/SKILL.md) (authored upstream by OpenAI). Transforms applied: align, rescope, debrand, minimize. Narrowed \`allowed-tools\` to \`Read, Grep, Glob, Write\`; dropped the Codex-specific HSTS framing.
- **FrontendDesign** — adopted from aitmpl's [\`frontend-design\`](https://github.com/davila7/claude-code-templates/blob/1deb97c72161528f6b7d84bc5117ae4be2e42735/cli-tool/components/skills/creative-design/frontend-design/SKILL.md) (17k+ installs as of 2026-02). Transforms: align, rescope, minimize (heavy). Preserved the aesthetic axes and anti-patterns; cut the motivational tails and repeated emphasis.
- **SkillDiscipline** — adopted from aitmpl's [\`using-superpowers\`](https://github.com/davila7/claude-code-templates/blob/af0b99278d2f8b705bdf700f19c3125c05de7ede/cli-tool/components/skills/development/using-superpowers/SKILL.md). Transforms: align, rescope, debrand (superpowers brand removed), minimize. Preserved the skill-check workflow, the dot-graph, and the red-flags table.

Each skill ships with a SLSA v1.0 provenance sidecar under \`.provenance/\` pinning the upstream commit SHA and listing every transform skill applied as \`resolvedDependencies\` per [PROV-0006](docs/decisions/PROV-0006%20Adoption%20Metadata%20in%20Provenance%20Sidecars.md).

## Test plan

- [x] \`forge validate .\` passes
- [x] Each sidecar lists the upstream source, \`ForgeAdopt\`, and every applied transform skill with pinned SHAs
- [x] Adopted skills pass the forge skill \`.mdschema\`
- [x] CI passes on this PR