### PR TITLE
chore: capture session learnings and adopt shared release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,45 +9,6 @@ permissions:
 
 jobs:
     release:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v6
-
-            - uses: N4M3Z/forge-cli/.github/actions/setup-forge@main
-
-            - name: Assemble
-              run: forge assemble .
-
-            - name: Package providers
-              env:
-                  VERSION: ${{ github.ref_name }}
-              run: |
-                  for provider in build/*/; do
-                      name=$(basename "$provider")
-                      stage="dist/forge-core-${name}-${VERSION}"
-                      mkdir -p "$stage"
-                      cp -r "$provider" "$stage/.${name}"
-                      cp README.md "$stage/README.md"
-                      cat > "$stage/Makefile" <<MAKEFILE
-                  # forge-core ${name} release
-                  #   make install                  # user scope
-                  #   make install SCOPE=workspace  # project scope
-                  SCOPE ?= user
-                  ifeq (\$(SCOPE),workspace)
-                      TARGET := .${name}
-                  else
-                      TARGET := \$(HOME)/.${name}
-                  endif
-                  .PHONY: install
-                  install:
-                  	@cp -r .${name}/* "\$(TARGET)/"
-                  	@echo "Installed to \$(TARGET)/"
-                  MAKEFILE
-                      tar czf "${stage}.tar.gz" -C dist "forge-core-${name}-${VERSION}"
-                  done
-
-            - name: Create release
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  VERSION: ${{ github.ref_name }}
-              run: gh release create "$VERSION" dist/forge-core-*-"${VERSION}".tar.gz --title "$VERSION" --generate-notes
+        uses: N4M3Z/forge-cli/.github/workflows/module-release.yaml@main
+        permissions:
+            contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ config.yaml
 
 # Build artifacts
 build/
+dist/
 
 # Plans (gitignored but folder kept)
 docs/plans/*

--- a/rules/ArchitectureDecisionRecords.md
+++ b/rules/ArchitectureDecisionRecords.md
@@ -6,4 +6,6 @@ Before proposing architectural changes or challenging existing patterns, check t
 
 After writing an ADR with body-level links to other ADRs, backfill those references into the `related:` frontmatter field. Body links are for human navigation; `related:` is for machine-readable cross-referencing.
 
+When modifying code in an area governed by an ADR, re-read the ADR and verify it still describes reality. Drift between ADR claims and actual behavior is a docs bug — fix the ADR (or the code) before layering new behavior on top.
+
 [MADR]: https://github.com/zircote/structured-madr

--- a/rules/BehavioralSteering.md
+++ b/rules/BehavioralSteering.md
@@ -8,7 +8,14 @@ These thoughts mean STOP — you're rationalizing a bad decision:
 | "Tests aren't needed for this"           | If it can break, it needs a test.                                |
 | "Let me add error handling just in case" | Don't guard against scenarios that can't happen.                 |
 | "I'll create a helper for this"          | Three similar lines beat a premature abstraction.                |
+| "I'll write a function to do X"          | Check if X already exists. Scaffold around it instead of reimplementing. |
 | "The user probably wants me to also..."  | Do what was asked. Ask before expanding.                         |
 | "I can skip reading the file"            | Read before claiming. Every shortcut is a future bug.            |
 | "Quick fix for now, investigate later"   | Root cause first. Symptom fixes create new bugs.                 |
 | "I'm confident it works"                 | Confidence is not evidence. Run the command.                     |
+| "Propose the full framework, then trim"  | First pass gets heavily cut. Start minimal; scope up on demand.          |
+| "I know how this tool or format works"   | External-behavior claims need evidence. Read docs or say you're unsure.  |
+| "I'll design what should exist here"     | Scan existing skills and modules first. New usually collides with old.   |
+| "This short message clearly means X"     | Short messages are easy to misread. Re-read before acting on new work.   |
+| "More detail is safer than less"         | Bloat is unsafe. Fewer structured points beat a longer response.         |
+| "I'll create a new task/branch/stash"    | State entropy. Reuse state; cleanup beats accumulation.                  |

--- a/rules/KnownIssues.md
+++ b/rules/KnownIssues.md
@@ -3,3 +3,9 @@ Do not symlink plugins into the cache — Claude Code periodically wipes `~/.cla
 Obsidian Linter auto-formats frontmatter between read and write, causing "file modified since read" errors with the Edit tool.
 
 `ekctl` (EventKit CLI) and other data-gathering tools (slackdump, DiscordChatExporter.Cli, sqlite3, m365) are pre-approved in `sandbox.excludedCommands` in both `settings.json` and `settings.local.json`. macOS TCC permissions are separate and must also be granted for EventKit tools.
+
+If the [safety-net][SAFETY] plugin is installed, the following commands are blocked from AI agents: `rm -rf` outside cwd, `git reset --hard`, `find -delete`, force-push to main, `git branch -D` (force-delete branches), `git checkout` with shell redirects parsed as positional args. For destructive ops, either hand the command back to the user to run in their own terminal, or use less-aggressive alternatives (`git stash`, `find -print | xargs rm`, `git switch` instead of `git checkout`).
+
+[SAFETY]: https://github.com/kenryu42/claude-code-safety-net
+
+Subagents spawned with `mode: 'auto'` cannot write to git submodule paths even with `bypassPermissions`. Symptom: agent reports completion but no files were created. Workaround: do the writes from the parent session, or accept the permission prompt manually when it surfaces.

--- a/rules/PlaintextTemplateVariables.md
+++ b/rules/PlaintextTemplateVariables.md
@@ -9,3 +9,5 @@ category: ${CATEGORY}                      %% architecture, process, governance,
 ```
 
 Variable names are UPPER_SNAKE_CASE. Names should be self-documenting — `${OPTION_1_DESCRIPTION}` not `${DESC}`. The comment adds context the name alone cannot convey (valid values, sentence length, relationship to other fields).
+
+When generating files programmatically (Makefile, YAML, config), embed the template via `include_str!` (Rust) or equivalent and substitute variables at runtime. Don't build content with `format!()` or string concatenation — it's harder to test, harder to read, and whitespace-sensitive output (Make recipes need tabs) gets mangled by Rust's auto-formatter or other tooling. Same principle as test fixtures (see InertFixtures): file content lives in files, not inline strings.

--- a/rules/PullRequests.md
+++ b/rules/PullRequests.md
@@ -19,3 +19,9 @@ When a repository is managed by a supported platform (GitHub, GitLab), you MUST 
 - **Feedback First**: If told there is feedback, immediately use `gh pr view --comments` or `gh pr view --web` before asking for clarification.
 - **Discovery**: Check `gh pr list` or `gh issue list` to avoid duplicating existing work.
 - **Operations**: Use CLI tools for PR creation (`--fill`), status checks, and merging.
+
+### Stacked PRs
+
+When a feature branch targets another feature branch as its base, the child PR's content does not cascade to main when the parent PR merges. Squash-merging PR A (`feature-A` → `main`) creates a new commit on main with A's content but leaves `origin/feature-A` as a divergent branch. PR B (`feature-B` → `feature-A`) then merges into the divergent `feature-A`, not main.
+
+Retarget PR B to main after PR A merges, or it will appear "merged" on GitHub while its content never reaches main.

--- a/rules/UseForge.md
+++ b/rules/UseForge.md
@@ -7,3 +7,5 @@ Assembly deploys only `.md` files. Non-markdown files (Python scripts, shell scr
 `--target ~` deploys to user scope (`~/.claude/`, `~/.codex/`, etc.). The flag sets the base directory for provider directories. `--target ~/.claude` is wrong — it nests `~/.claude/.claude/`.
 
 In CI, install forge via the composite action: `uses: N4M3Z/forge-cli/.github/actions/setup-forge@main`. Supports version pinning (`version: v0.3.0`), caching, and platform detection.
+
+`build/` is transient — `forge assemble` wipes it on every run. `dist/` is preserved — release artifacts and anything that must survive subsequent `forge install` calls go there. Don't put release tarballs in `build/`; subsequent install will silently destroy them.

--- a/rules/VerifyClaims.md
+++ b/rules/VerifyClaims.md
@@ -5,3 +5,5 @@ When writing skill companions that document CLI tools, verify every command path
 When uncertain, verify before stating: spawn a `WebResearcher` agent, use the `Explore` agent for codebase search, fetch URLs with `WebFetch`, or `Grep` locally. Verification takes seconds; recovering from a fabricated claim takes the whole session.
 
 Fabricated names erode trust faster than any bug.
+
+When claiming that Tool B supersedes Tool A, prove it empirically. Run both tools against identical fixtures and show the error output matches. Schema-level analysis ("they both check required fields") is insufficient — a subtle constraint in one tool might be missing from the other, and only running them reveals the gap.

--- a/skills/ForgeAdopt/SKILL.md
+++ b/skills/ForgeAdopt/SKILL.md
@@ -125,3 +125,4 @@ One commit per adoption. Commit message carries the prose rationale — what was
 - Every adoption writes a provenance sidecar; an adoption without provenance is not an adoption
 - Defer the adoption if no existing module is a natural home; do not create new modules for one skill
 - Adopt at most 3-5 skills in the initial phase — selectivity is the point
+- Recompute the adopted artifact's SHA-256 and sync it to the provenance sidecar after ANY post-adoption edit. The sidecar's `subject.digest.sha256` must match the current file content, not the initial adoption state

--- a/skills/LearnFrom/SKILL.md
+++ b/skills/LearnFrom/SKILL.md
@@ -26,31 +26,51 @@ Review the current conversation and identify:
 
 For each item, apply the reusability test: will I encounter this again? If no, skip it.
 
-Determine the target artifact:
+## Scan Existing Artifacts FIRST
+
+Before drafting any proposal, list every file in `rules/`, `skills/`, and `agents/` of the target module. For each candidate learning, search by topic for an existing artifact that already touches the same area. The default outcome is a one-line edit to an existing file, NOT a new file.
+
+Concrete signals you should be editing not creating:
+- Topic overlap: existing rule covers the same domain (git, bash, markdown, ADRs)
+- Adjacent guidance: existing skill mentions the same tool or workflow
+- Sibling concept: existing rule covers the inverse or a related case
+
+Only create a new file when the learning is genuinely orthogonal to everything that exists. If you find yourself writing a rule shorter than ~3 sentences, it almost certainly belongs as a paragraph in an existing file.
+
+Determine the target artifact. The categorization decision matters — rules cost tokens every session; skills cost tokens only when invoked.
 
 | Learning type              | Target           | Example                                      |
 | -------------------------- | ---------------- | -------------------------------------------- |
-| Convention or constraint   | `rules/`         | "every text file ends with newline"          |
+| Always-relevant constraint | `rules/`         | "every text file ends with newline"          |
+| Task-specific guidance     | `skills/*/SKILL.md` with `paths:` | "shell scripting pitfalls — auto-trigger on `**/*.sh`" |
 | Skill workflow improvement | `skills/*/`      | "add note about tool limitation"             |
 | Agent instruction update   | `agents/`        | "add guidance about deployment scope"        |
 | Existing file refinement   | edit in place     | "add RACI to required frontmatter list"      |
 
+If the guidance only matters when working on certain files (shell scripts, Python, Markdown), make it a skill with `paths:` frontmatter so it auto-triggers on relevant file edits — don't put it in `rules/` where it loads on every session regardless of relevance.
+
 ## Draft Proposals
 
-For each identified learning, draft a concrete proposal:
+For each identified learning, draft a concrete proposal in this priority order:
 
-- **New rule**: filename and content (concise, actionable)
-- **Rule update**: which file, what to add or change
-- **Skill update**: which companion file, what to add or change
-- **Agent update**: which agent, what to add or change
+1. **Append to existing rule** — one paragraph added to an in-topic file
+2. **Append to existing skill body** — for skill-scoped guidance
+3. **Edit existing agent instructions** — for agent-specific behavior
+4. **New rule or skill** — only when no existing artifact fits
+
+Show the existing-file scan result alongside each proposal so the user can see what was considered and rejected.
+
+Rules must fire on a concrete trigger. Abstract principles ("be careful with X") don't change behavior; concrete signals do ("when you're about to write Y, check Z"). Iterate the wording with the user — first drafts are usually too abstract OR too tied to one specific case. Filename should match the final framing — rename if the concept shifts during iteration.
 
 ## Interactive Review
 
-Present proposals in batches via AskUserQuestion.
+Present proposals in batches via AskUserQuestion (4 questions max per call).
 
-For each proposal, show the target file and proposed change. Options: "Capture", "Adjust", "Skip".
+For each proposal, show the target file and proposed change with a `preview` field carrying the literal content that would be written. Options: "Capture", "Adjust", "Skip".
 
 For "Adjust": ask what to change, then re-present.
+
+After the first batch, dig deeper before declaring done. Most sessions have 2-3 obvious learnings and several non-obvious ones surfaced only by re-scanning corrections, pushback, and stuck moments. Ask yourself "what else did the user have to correct?" before stopping.
 
 ## Apply Changes
 
@@ -68,7 +88,9 @@ List what was captured: rules created or updated, skills updated, agents updated
 
 ## Constraints
 
-- Never write a rule that duplicates an existing one — check `rules/` first. Prefer adding to an existing rule over creating a new file when the learning fits an existing topic
+- Scan existing `rules/`, `skills/`, and `agents/` BEFORE drafting — a new file is the last resort, not the first instinct
+- A learning shorter than ~3 sentences belongs in an existing file as an appended paragraph
 - Keep rules concise (max 120 words per section per the rules `.mdschema`)
 - New rules follow the `.mdschema` in `rules/` if present
 - Apply the reusability filter strictly — session-specific fixes are not rules
+- Validate against the target directory's `.mdschema` before writing

--- a/skills/VersionControl/SKILL.md
+++ b/skills/VersionControl/SKILL.md
@@ -43,6 +43,31 @@ Keep the first line under 72 characters. Add a blank line and body for context w
 - Body format: `## Summary` (1-3 bullets) + `## Test plan` (checklist)
 - Create from a feature branch, never directly from main
 
+## Post-Merge Branch Cleanup
+
+After a PR merges, delete the local and remote branch — feature branches accumulate fast and squash-merges leave them behind.
+
+Squash-merge changes the commit hash, so `git branch -d` refuses with "not fully merged." Verify state via the platform first, then force-delete:
+
+```sh
+# Verify merge state per branch (gh / glab)
+gh pr list --head feat/my-branch --state all --limit 1
+
+# Local — squash-merged branches need -D
+git branch -D feat/my-branch
+
+# Remote — separate operation
+git push origin --delete feat/my-branch
+```
+
+If the [safety-net][SAFETY] plugin is installed, `git branch -D` is blocked from AI agents (force-delete bypasses the merge check). Hand the command back to the user to run in their own terminal — write out the exact command in a shell block and ask them to execute it. Same applies for `git push origin --delete` if the safety net is configured to block remote-destructive operations.
+
+[SAFETY]: https://github.com/kenryu42/claude-code-safety-net
+
+For local branches whose remote was deleted but the local copy lingers, use `git fetch --prune` then the `commit-commands:clean_gone` skill (or `git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D`).
+
+Use `git switch <branch>` rather than `git checkout <branch>` — checkout's positional args parse ambiguously and trip safety nets.
+
 ## Repo Governance
 
 Platform-specific branch protection, rulesets, and code ownership.


### PR DESCRIPTION
## Summary

- Capture transferable learnings from recent sessions as rule additions and skill refinements
    - `BehavioralSteering.md`, `KnownIssues.md`, `PullRequests.md`, `UseForge.md`, `VerifyClaims.md`, `PlaintextTemplateVariables.md`, `ArchitectureDecisionRecords.md`
    - `LearnFrom` skill: emphasize scanning existing artifacts before drafting, prioritize edits over new files
    - `VersionControl` skill: add post-merge branch cleanup guidance (squash-merge -D, safety-net handoff)
    - `ForgeAdopt` skill: note to recompute SHA-256 after post-adoption edits
- Replace inline `release.yaml` steps with the shared `N4M3Z/forge-cli/.github/workflows/module-release.yaml` composite workflow
- Add `dist/` to `.gitignore`

## Test plan

- [x] `make validate` passes (mdschemas, shellcheck, gitleaks, semgrep OWASP)
- [x] CI release workflow runs on next tag push