### PR TITLE
feat: capture session learnings — ProvenanceAudit skill + history rewrite + concrete LearnFrom triggers

### DIFF
--- a/rules/CrossProviderAssembly.md
+++ b/rules/CrossProviderAssembly.md
@@ -7,3 +7,7 @@ The `forge install` command (via `forge-cli`) transforms canonical source artifa
 3. **Cleanup**: Strips frontmatter, resolves companion files (`@`), and removes provenance markers to minimize token overhead in deployed files.
 
 Authors MUST author using the canonical Markdown form and standard tool names. Never write provider-specific formats (TOML) or use native tool names directly in the source repository.
+
+Assembly also rewrites provenance sidecars. Source-side `adopt/v1` sidecars (with upstream + AdoptArtifact dependencies) become `assemble/v1` sidecars at deploy, with a single-source input. The full adoption chain is preserved only in the source repo's `.provenance/` files. Audit deployed artifacts for tamper; audit source-repo sidecars for adoption history. See the [ProvenanceAudit][ProvenanceAudit] skill for operational procedures.
+
+[ProvenanceAudit]: skills/ProvenanceAudit/SKILL.md

--- a/rules/SelfLearning.md
+++ b/rules/SelfLearning.md
@@ -1,4 +1,11 @@
-After significant amount of work (multi-step implementations, agent team teardown, architecture decisions), invoke [LearnFrom][LEARNFROM] to capture transferable learnings before the session moves on.
+Invoke [LearnFrom][LEARNFROM] to capture transferable learnings whenever ANY of these fire during a session:
+
+- A council teardown (DeveloperCouncil, HiringCouncil, ProductCouncil, ResearchCouncil, VaultCouncil, KnowledgeCouncil, DebateCouncil)
+- A history rewrite touching 5+ commits (squash, force-push, rebase)
+- A skill, agent, or rule rename, move, or deletion
+- 3+ corrections from the user in a single topic (messages starting with `no`, `don't`, `actually`, `wait`, `stop`, `what are you doing`)
+- Before closing a work stream spanning 3+ merged PRs
+- After discovering a forge-cli / tool bug worth filing as an upstream issue
 
 [LearnFrom][LEARNFROM] scans the session, proposes updates to rules, skills, and agents, and presents each via AskUserQuestion with Capture / Adjust / Skip options.
 

--- a/rules/VerifyClaims.md
+++ b/rules/VerifyClaims.md
@@ -9,3 +9,7 @@ Fabricated names erode trust faster than any bug.
 When claiming that Tool B supersedes Tool A, prove it empirically. Run both tools against identical fixtures and show the error output matches. Schema-level analysis ("they both check required fields") is insufficient — a subtle constraint in one tool might be missing from the other, and only running them reveals the gap.
 
 When an agent returns assertions about file existence or constraint compliance ("all files verified on disk", "no duplicates against the exclusion list"), spot-check the critical claims before applying the output. Agents hallucinate about these reliably — treat such claims as proposals to verify, not facts.
+
+Counts that subagents report ("12 files verified", "3 sidecars updated") violate [NoItemCounts][NIC] and are unreliable besides. If one slips through, recompute it yourself with `ls | wc -l`, `rg -c`, or equivalent before citing it. The specialist's count is a proposal; your recount is the fact.
+
+[NIC]: NoItemCounts.md

--- a/skills/ProvenanceAudit/SKILL.md
+++ b/skills/ProvenanceAudit/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: ProvenanceAudit
+version: 0.1.0
+description: "Audit forge module provenance and deployment integrity — inspect deployed sidecars, detect drift, clean stale artifacts after renames, trace adoption chains. USE WHEN running forge provenance, auditing a deployed target, debugging drift, cleaning up after a skill rename, or investigating sidecar state."
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# ProvenanceAudit
+
+Operational procedures for auditing `.provenance/` sidecars in forge deployments and source repos. Complements [ProvenanceVerification][PROV] (what provenance means) and [CrossProviderAssembly][ASM] (how assembly rewrites sidecars).
+
+## Audit a deployed target
+
+`forge provenance` expects a deployed provider directory (`~/.claude`, `~/.opencode`, `~/.codex`, `~/.gemini`) — the deploy sidecars it reads are written by `forge install` in `assemble/v1` form. Running it against a source module (`forge provenance .` inside a repo) reports every subject as orphan, because source sidecars use `adopt/v1` or `init/v1` buildTypes that the audit reader doesn't resolve.
+
+```sh
+forge provenance ~/.claude                  # audit user-scope deployment
+forge provenance ~/.claude --show-orphans   # include unverified files
+forge provenance ~/.claude --json           # machine-readable output
+```
+
+Per-module results look like:
+
+```
+https://github.com/N4M3Z/forge-core → ✓ 156 verified
+https://github.com/N4M3Z/forge-dev  → ✓ 53 verified
+forge-text                           → ✗ 21/22 verified
+```
+
+A `✗` means at least one deployed file's digest doesn't match its sidecar — either a post-deploy edit or a tamper. Diff the deployed file against `build/<provider>/<path>` to identify what drifted.
+
+## Trace an adoption chain
+
+Deployed sidecars carry the `assemble/v1` buildType with a single input (the source file). The richer `adopt/v1` sidecar — with upstream URL, pinned commit, AdoptArtifact reference, and transform-skill digests — exists only in the source repo.
+
+```sh
+cat Modules/forge-dev/agents/.provenance/CodeReviewer.yaml
+# resolvedDependencies:
+#   - name: upstream
+#     uri: https://raw.githubusercontent.com/davila7/...
+#     digest: sha256:...
+#   - name: AdoptArtifact
+#     uri: forge-core/skills/AdoptArtifact/SKILL.md
+#     digest: sha256:...
+```
+
+Never expect the deployed sidecar to carry this — assembly strips it by design ([CrossProviderAssembly][ASM]).
+
+## Clean stale deployments after a rename
+
+`forge install` is additive, not idempotent for renames. After renaming `skills/OldName` → `skills/NewName` and reinstalling, the old directory persists at every deployed target. Explicit cleanup is required across every provider:
+
+```sh
+for provider in .claude .codex .opencode .gemini; do
+    dir="$HOME/$provider/skills/OldName"
+    [ -d "$dir" ] && rm -rf "$dir"
+done
+```
+
+If the safety-net plugin blocks `rm -rf` paths outside cwd, use a per-file loop (`find "$dir" -type f -delete; find "$dir" -type d -empty -delete`) or ask the user to run the cleanup in their terminal.
+
+After cleanup, confirm: `ls ~/.claude/skills/ | grep -iE "OldName|NewName"` should return only `NewName`.
+
+## Update sidecars across the rename's blast radius
+
+Renaming a skill, agent, or transform that appears as a `resolvedDependencies` entry in OTHER artifacts' sidecars has ecosystem-wide impact. Every sidecar referencing the old identifier (name, uri, digest if the content changed) must be updated:
+
+```sh
+# Find all sidecars that reference the old name as a dependency
+rg -l "name: OldName" --glob "**/.provenance/*.yaml"
+
+# Update in bulk — reuse a known-good new digest
+find . -name "*.yaml" -path "*.provenance*" | while read -r f; do
+    if grep -q "name: OldName" "$f"; then
+        sed -i '' \
+            -e 's|name: OldName|name: NewName|g' \
+            -e 's|skills/OldName/SKILL\.md|skills/NewName/SKILL.md|g' \
+            -e 's|<old-digest>|<new-digest>|g' \
+            "$f"
+    fi
+done
+```
+
+Before calling a rename complete, grep the entire `Modules/` tree for the old name — sidecars in sibling modules are the most-missed targets.
+
+## Debug orphan reports
+
+`--show-orphans` lists deployed files with no sidecar. Common causes:
+
+- File was added manually (bypassing `forge install`) — reinstall or delete
+- Sidecar naming mismatch — forge expects `<basename>.yaml` but some writers produce `<basename>.md.yaml` (see [forge-cli#31][CLI31])
+- Provider-specific discovery gap — `.codex` deployments may report "No provenance found" despite sidecars present (see [forge-cli#29][CLI29])
+
+Known forge-cli limitations: `adopt/v1` sidecars aren't rendered by the CLI (schema mismatch on `externalParameters.source` — see [forge-cli#30][CLI30]). For those, `cat` the YAML directly.
+
+[PROV]: ../../rules/ProvenanceVerification.md
+[ASM]: ../../rules/CrossProviderAssembly.md
+[CLI29]: https://github.com/N4M3Z/forge-cli/issues/29
+[CLI30]: https://github.com/N4M3Z/forge-cli/issues/30
+[CLI31]: https://github.com/N4M3Z/forge-cli/issues/31

--- a/skills/VersionControl/SKILL.md
+++ b/skills/VersionControl/SKILL.md
@@ -33,9 +33,31 @@ Keep the first line under 72 characters. Add a blank line and body for context w
 
 ## Push Policy
 
-- Never force-push (`--force`, `--force-with-lease`) unless the user explicitly asks
+- Never force-push unless the user explicitly asks. When force-pushing is sanctioned, default to `--force-with-lease` not `--force` — lease fails fast if the remote moved since your last fetch, and safety-net plugins allow lease while blocking raw force
 - Never skip hooks (`--no-verify`) unless the user explicitly asks
 - Do not push unless the user asks — committing and pushing are separate actions
+
+## History Rewrite
+
+When squashing, reordering, or rebuilding a linear history, `git read-tree -u --reset <sha>` is the cleanest primitive — it snaps the index and working tree to any commit's tree state without running a merge or rebase. Build the new history by iterating target commits:
+
+```sh
+git branch backup-pre-squash            # always create a safety branch first
+git checkout --orphan squashed-tmp
+git read-tree -u --reset <end-of-group-1-sha>
+git commit -m "<new message 1>"
+git read-tree -u --reset <end-of-group-2-sha>
+git commit -m "<new message 2>"
+# repeat for each group, then swap branches
+git branch -f main squashed-tmp
+git switch main
+git branch -d squashed-tmp
+git push --force-with-lease origin main
+```
+
+Respect commit chronology when grouping. Squashing by theme fails when commits are interleaved across themes — the end-of-group tree snapshot inherits every earlier commit's content, so a commit titled "Rust rules" also carries whatever unrelated work preceded it. Group along the chronological spine and name commits by the actual content in each tree snapshot.
+
+Before any destructive rewrite, create a backup branch (`git branch backup-pre-<op>`). Costs nothing, preserves the old tip for recovery, and lets you diff the rewritten history against the original to confirm content parity before force-pushing.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

- New `skills/ProvenanceAudit/` — operational skill covering deployed-target audits, adoption chain tracing, stale-deployment cleanup after renames, sidecar blast-radius updates across modules
- `skills/VersionControl/SKILL.md` — new `History Rewrite` section (`git read-tree -u --reset` primitive, chronology constraint, backup-branch discipline); Push Policy refined to default `--force-with-lease` over `--force`
- `rules/CrossProviderAssembly.md` — paragraph on assembly rewriting `adopt/v1` sidecars to `assemble/v1` at deploy; pointer to ProvenanceAudit for ops
- `rules/VerifyClaims.md` — extend agent-hallucination guidance to cover numeric claims specifically (counts from subagents hallucinate reliably)
- `rules/SelfLearning.md` — replace vague "significant amount of work" trigger with concrete signals (council teardown, history rewrite of 5+ commits, skill rename/move, 3+ user corrections, 3+ PRs closing a stream, upstream bug filing)

## Test plan

- [x] `forge validate .` → all checks pass
- [x] Content split respects the rule/skill boundary: rules hold constraints and invariants; skills hold operational procedures
- [x] ProvenanceAudit skill cross-references existing rules rather than duplicating their content

## Why

A multi-hour forge-dev session produced 10 transferable learnings. LearnFrom didn't surface during the work because `SelfLearning.md` uses fuzzy phrase "significant amount of work" — no concrete trigger fires. This PR captures the learnings and rewrites the trigger rule so future sessions self-invoke.