### PR TITLE
feat: add NoEmDash rule and document hooks wiring

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ Deploy forge-core skills, agents, and rules to all AI providers via Makefile.
 - `make validate` passes
 - `ls ~/.claude/skills/BuildSkill/SKILL.md` confirms skill deployment
 - `git config core.hooksPath` returns `.githooks`
+- `~/.claude/settings.json` contains the `hooks` block with forge-core hook commands
 
 ## Prerequisites
 
@@ -30,6 +31,7 @@ Without Rust: copy `skills/`, `agents/`, `rules/` into the provider config direc
 - [ ] Clone the repository
 - [ ] Install forge-cli
 - [ ] Run `make install` to deploy
+- [ ] Wire Claude Code hooks into `~/.claude/settings.json`
 - [ ] Verify skill deployment
 - [ ] Verify git hooks are active
 
@@ -68,6 +70,12 @@ cd ../forge-core
 ```sh
 make install
 ```
+
+### Wire Claude Code hooks
+
+`forge install` deploys skills, agents, and rules, but not hooks. Claude Code hooks must be wired manually into `~/.claude/settings.json`.
+
+Read `hooks/hooks.json` in this repository: it lists every hook, its event, matcher, and command. For each entry, add a corresponding record to the `hooks` key in `~/.claude/settings.json`, replacing `${CLAUDE_PLUGIN_ROOT}` with the absolute path to your clone.
 
 ### Verify skill deployment
 

--- a/rules/NoEmDash.md
+++ b/rules/NoEmDash.md
@@ -1,0 +1,3 @@
+Never use em dashes (—) in prose. They are a strong signal of AI-generated text and immediately break trust with human readers.
+
+Use alternatives that fit the sentence structure: a comma, a colon, parentheses, or split into two sentences.

--- a/rules/UseForge.md
+++ b/rules/UseForge.md
@@ -2,6 +2,8 @@ Forge assembles and deploys module content to AI provider directories. Key behav
 
 Assembly deploys only `.md` files. Non-markdown files (Python scripts, shell scripts, YAML sidecars) in skill directories are silently dropped. Ship executables in `bin/` at the plugin root instead.
 
+`forge install` deploys rules, skills, and agents, not hooks. Wire hooks manually into `~/.claude/settings.json` using absolute paths. Read the module's `hooks/hooks.json` for the full hook list and replace `${CLAUDE_PLUGIN_ROOT}` with the absolute path to your clone.
+
 `--force` overwrites user-modified deployed files but does not re-assemble from source. Clear the build cache (`rm -rf build/`) before reinstalling if source changed since last assembly.
 
 `--target ~` deploys to user scope (`~/.claude/`, `~/.codex/`, etc.). The flag sets the base directory for provider directories. `--target ~/.claude` is wrong — it nests `~/.claude/.claude/`.


### PR DESCRIPTION
## Summary

- New rule `rules/NoEmDash.md` flags em dashes (—) in prose as an AI-text signal that breaks reader trust. Suggests commas, colons, parentheses, or sentence splits as alternatives.
- `rules/UseForge.md` adds a paragraph noting that `forge install` does not deploy hooks. Points to the module's `hooks/hooks.json` and tells readers to substitute `${CLAUDE_PLUGIN_ROOT}` with their clone path.
- `INSTALL.md` adds a "Wire Claude Code hooks" step (plus matching TODO bullet and DONE WHEN check). Instructs readers to read `hooks/hooks.json` rather than embedding a JSON snippet, so the doc does not rot as the hook list evolves.

## Test plan

- [x] `make validate` passes locally
- [x] `forge install . --target ~` deploys `~/.claude/rules/NoEmDash.md` and updated `~/.claude/rules/UseForge.md`
- [ ] CI green