### PR TITLE
docs: ARCH-0014 per-tool memory files

### DIFF
--- a/docs/decisions/ARCH-0014 Per-Tool Memory Files.md
+++ b/docs/decisions/ARCH-0014 Per-Tool Memory Files.md
@@ -60,7 +60,7 @@ When a new tool integration arrives (e.g., Codex creates its own `AGENTS.md` wit
 ### Mitigations
 
 - Periodic doc reviews catch material drift between files.
-- The companion rule [PerToolMemoryFiles][RULE] gives an always-loaded directive against merging or cross-importing these files.
+- The companion rule [IsolateHarnessMemory][RULE] gives an always-loaded directive against merging or cross-importing these files.
 - Content that genuinely belongs in one place (deployment internals, ADR index, FAQ) lives in `docs/` or `ARCHITECTURE.md`, not in tool memory files.
 
 ## Related Decisions
@@ -70,4 +70,4 @@ When a new tool integration arrives (e.g., Codex creates its own `AGENTS.md` wit
 
 [AGENTSMD]: https://agents.md "AGENTS.md cross-tool standard"
 [CCMEM]: https://code.claude.com/docs/en/memory "Claude Code memory documentation"
-[RULE]: ../../rules/PerToolMemoryFiles.md
+[RULE]: ../../rules/IsolateHarnessMemory.md

--- a/docs/decisions/ARCH-0014 Per-Tool Memory Files.md
+++ b/docs/decisions/ARCH-0014 Per-Tool Memory Files.md
@@ -1,0 +1,73 @@
+---
+title: "Per-Tool Memory Files"
+description: "Each AI tool's primary memory file (CLAUDE.md, AGENTS.md, GEMINI.md) stays self-contained, not imported or generated from a shared canonical source"
+type: adr
+category: architecture
+tags:
+    - architecture
+    - documentation
+    - cross-tool
+status: accepted
+created: 2026-04-23
+updated: 2026-04-23
+author: "@N4M3Z"
+project: forge-core
+related:
+    - "ARCH-0008 Multi-Provider Support.md"
+    - "ARCH-0001 Skills Agents and Rules.md"
+responsible: ["@N4M3Z"]
+accountable: ["@N4M3Z"]
+consulted: []
+informed: []
+upstream: []
+---
+
+# Per-Tool Memory Files
+
+## Context and Problem Statement
+
+Modules host content for several AI tools (Claude Code, Codex, Gemini, OpenCode). Each tool reads its own primary memory file from the repo root: Claude Code reads `CLAUDE.md`, Codex reads `AGENTS.md` ([agents.md][AGENTSMD]), Gemini reads `GEMINI.md`. Claude Code's memory documentation states explicitly: *"Claude Code reads `CLAUDE.md`, not `AGENTS.md`"* ([Claude memory docs][CCMEM]), and recommends importing `AGENTS.md` from `CLAUDE.md` if both must share content.
+
+Two approaches present themselves: keep one canonical file (e.g., `AGENTS.md`) and have all others import or symlink to it, or keep one file per tool with deliberate isolation. The question is whether convergence or divergence is the more sustainable default as the tool roster grows.
+
+## Decision Drivers
+
+- Each tool has its own quirks: load order, comment syntax, import directives (`@path` for Claude Code, none for Codex), context-window limits (Claude Code recommends under 200 lines; Codex has no documented limit), hook system, plugin model. Guidance optimal for one tool can be wrong for another.
+- New tool integrations should be additive, not refactors of existing files.
+- A single canonical file invites tool-specific guidance to leak into shared content. Once that happens, the other tool's behavior becomes unpredictable.
+- Multi-provider support ([ARCH-0008](ARCH-0008 Multi-Provider Support.md)) already establishes per-provider artifact isolation for skills and agents. Memory files follow the same logic.
+
+## Considered Options
+
+1. **Single canonical source with per-tool imports** — `AGENTS.md` is canonical, `CLAUDE.md` contains `@AGENTS.md`, `GEMINI.md` symlinks. One source of truth, automatic sync.
+2. **Per-tool files, deliberately separate** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` each maintained independently. Some duplication, no cross-tool coupling.
+3. **Generated per-tool files from a canonical source** — a build step renders per-tool variants from a master document with provider-specific sections.
+
+## Decision Outcome
+
+Chosen option: **per-tool files, deliberately separate**. Each tool's primary memory file lives at the repo root, owned by that tool, and is internally complete. Authors do not import or symlink between them. Some content (project structure, build commands) appears in multiple files; this is the accepted cost of tool isolation.
+
+When a new tool integration arrives (e.g., Codex creates its own `AGENTS.md` with Codex-specific quirks), existing files are not touched. When a tool-specific behavior is documented, it lands only in that tool's file.
+
+### Consequences
+
+- [+] Tool quirks stay isolated. A Claude Code plan-mode instruction in `CLAUDE.md` cannot accidentally apply to Codex.
+- [+] New tool integrations are additive, not refactors.
+- [+] Each file can be tuned for its tool's loading model — `CLAUDE.md` benefits from being concise per the [Claude memory docs][CCMEM]; `AGENTS.md` has no such limit.
+- [-] Shared content (project structure, build commands, conventions) is duplicated across files and can drift.
+- [-] No automated mechanism to flag drift; relies on periodic audits.
+
+### Mitigations
+
+- Periodic doc reviews catch material drift between files.
+- The companion rule [PerToolMemoryFiles][RULE] gives an always-loaded directive against merging or cross-importing these files.
+- Content that genuinely belongs in one place (deployment internals, ADR index, FAQ) lives in `docs/` or `ARCHITECTURE.md`, not in tool memory files.
+
+## Related Decisions
+
+- [ARCH-0008](ARCH-0008 Multi-Provider Support.md) — establishes per-provider artifact isolation for skills and agents
+- [ARCH-0001](ARCH-0001 Skills Agents and Rules.md) — defines the artifact classes that load alongside memory files
+
+[AGENTSMD]: https://agents.md "AGENTS.md cross-tool standard"
+[CCMEM]: https://code.claude.com/docs/en/memory "Claude Code memory documentation"
+[RULE]: ../../rules/PerToolMemoryFiles.md

--- a/rules/IsolateHarnessMemory.md
+++ b/rules/IsolateHarnessMemory.md
@@ -1,0 +1,5 @@
+Each AI harness's memory file at the repo root (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.codex/AGENTS.md`, etc.) is self-contained. Do not collapse them into a single canonical file or import one from another via `@path`, symlinks, or build-step generation.
+
+Harness-specific guidance (plan mode, hook syntax, import directives, context-window limits) belongs only in that harness's file. Shared content (project structure, build commands) appearing in multiple files is the accepted cost of harness isolation.
+
+Reasoning: [ARCH-0014 Per-Tool Memory Files](../docs/decisions/ARCH-0014 Per-Tool Memory Files.md).

--- a/rules/PerToolMemoryFiles.md
+++ b/rules/PerToolMemoryFiles.md
@@ -1,5 +1,0 @@
-Each AI tool's memory file at the repo root (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.codex/AGENTS.md`, etc.) is self-contained. Do not collapse them into a single canonical file or import one from another via `@path`, symlinks, or build-step generation.
-
-Tool-specific guidance (plan mode, hook syntax, import directives, context-window limits) belongs only in that tool's file. Shared content (project structure, build commands) appearing in multiple files is the accepted cost of tool isolation.
-
-Reasoning: [ARCH-0014 Per-Tool Memory Files](../docs/decisions/ARCH-0014 Per-Tool Memory Files.md).

--- a/rules/PerToolMemoryFiles.md
+++ b/rules/PerToolMemoryFiles.md
@@ -1,0 +1,5 @@
+Each AI tool's memory file at the repo root (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.codex/AGENTS.md`, etc.) is self-contained. Do not collapse them into a single canonical file or import one from another via `@path`, symlinks, or build-step generation.
+
+Tool-specific guidance (plan mode, hook syntax, import directives, context-window limits) belongs only in that tool's file. Shared content (project structure, build commands) appearing in multiple files is the accepted cost of tool isolation.
+
+Reasoning: [ARCH-0014 Per-Tool Memory Files](../docs/decisions/ARCH-0014 Per-Tool Memory Files.md).


### PR DESCRIPTION
## Summary

- Adds [ARCH-0014][ARCH] codifying that each AI harness's primary memory file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) stays self-contained — no canonical-source-with-imports, no symlinks, no generation.
- Adds [IsolateHarnessMemory][RULE] as the always-loaded companion rule (renamed from `PerToolMemoryFiles` per review feedback).
- Reasoning: each harness has its own quirks (load order, import directives, context-window limits, plugin model). Convergence invites cross-harness conflicts; isolation accepts mild duplication as the cost.

The `forge validate .` → `forge validate` hook fix that previously rode along here lives in #37, where it belongs.

[ARCH]: docs/decisions/ARCH-0014%20Per-Tool%20Memory%20Files.md
[RULE]: rules/IsolateHarnessMemory.md

## Test plan

- [x] ADR conforms to structured-madr required frontmatter (`title`, `description`, `type`, `category`, `tags`, `status`, `created`, `updated`, `author`, `project`, RACI fields, `upstream`)
- [x] Rule body is short, specific, references the ADR
- [x] Rule renamed and cross-references updated (rule file, ADR `[RULE]` reflink, ADR body mention)
- [x] No harness-specific guidance baked into the new files (the decision is *about* keeping such guidance separate)
- [ ] Adoption into downstream modules tracked separately
