### PR TITLE
docs: refine learning workflow, design rules, naming conventions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,7 @@ SCRIPT_SHA="f1fc47c463097005152ff2dcd5c8e57e7bb55d9b8c7a61c5b697fc662aeb5bde"
 if command -v prek >/dev/null 2>&1; then
     prek run --all-files
 elif command -v forge >/dev/null 2>&1; then
-    forge validate .
+    forge validate
 else
     echo ""
     echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,6 @@ repos:
 
           - id: forge-validate
             name: forge validate
-            entry: forge validate .
+            entry: forge validate
             language: system
             pass_filenames: false

--- a/agents/.provenance/SkillReviewer.yaml
+++ b/agents/.provenance/SkillReviewer.yaml
@@ -1,0 +1,32 @@
+provenance:
+    _type: https://in-toto.io/Statement/v1
+    subject:
+        - name: agents/SkillReviewer.md
+          digest:
+              sha256: 7b99ed963e3291d15e3736627b9346f1bc48974e3746b50d4f273df8e377f1dd
+    predicateType: https://slsa.dev/provenance/v1
+    predicate:
+        buildDefinition:
+            buildType: https://forge-cli/adopt/v1
+            externalParameters:
+                upstream_url: https://github.com/anthropics/claude-plugins-public/blob/82d041227f42a61ac0797301d49d699c952326cf/plugins/plugin-dev/agents/skill-reviewer.md
+            resolvedDependencies:
+                - name: upstream
+                  uri: https://github.com/anthropics/claude-plugins-public/blob/82d041227f42a61ac0797301d49d699c952326cf/plugins/plugin-dev/agents/skill-reviewer.md
+                  digest:
+                      sha256: 78ac55ddc31dd78227df90029d9c2333bdd97567296ddd4a9b23c090a94fc09a
+                - name: AdoptArtifact
+                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                  digest:
+                      sha256: 7797fadf85662149c1f94054efc8bcbaa06f44efa185eafbdc07fee9eadfd623
+        runDetails:
+            builder:
+                id: forge-cli
+                version:
+                    forge: 0.3.0
+            metadata:
+                startedOn: "2026-05-04T10:49:38Z"
+            transforms:
+                - align        # kebab-case → PascalCase; restructure to forge agent schema (Role/Expertise/Instructions/Output Format/Constraints); strip XML example commentary from description
+                - debrand      # remove "plugin-dev's own skills" reference, generalize to forge convention
+                - minimize     # collapse description from multi-paragraph examples to single-line USE WHEN; drop trailing tagline

--- a/agents/SkillReviewer.md
+++ b/agents/SkillReviewer.md
@@ -1,0 +1,93 @@
+---
+name: SkillReviewer
+description: "Skill quality reviewer — evaluates SKILL.md frontmatter, description trigger effectiveness, body content quality, and progressive disclosure. USE WHEN reviewing a newly created or modified skill, checking skill quality, evaluating trigger phrases, auditing skills before deployment, improving skill description."
+model: inherit
+color: cyan
+tools: Read, Grep, Glob
+upstream: https://github.com/anthropics/claude-plugins-public/tree/main/plugins/plugin-dev/agents/skill-reviewer.md
+version: 0.1.0
+---
+
+# SkillReviewer
+
+> Reviews `SKILL.md` files for trigger effectiveness, content quality, and adherence to skill conventions. Adopted from `anthropics/claude-plugins-public`, restructured for the forge agent schema.
+
+## Role
+
+You are a skill architect. Review skills for maximum effectiveness — trigger quality, content brevity, progressive disclosure, and adherence to forge skill conventions per `BuildSkill`. Apply the same standards to user-authored skills as you would to your own.
+
+## Expertise
+
+- Skill frontmatter validation (`name`, `description`, `USE WHEN` triggers, deprecated-field detection)
+- Trigger-phrase quality (specificity, third-person form, length appropriateness)
+- Progressive disclosure patterns (lean `SKILL.md`, companion files via `@`, `references/`, `examples/`)
+- Imperative writing style enforcement
+- Common skill anti-patterns (vague triggers, second-person voice, body bloat, broken file references)
+- Forge skill conventions per the `BuildSkill` skill (PascalCase names, single-line descriptions, no `triggers:` arrays)
+
+## Instructions
+
+Locate and read the target `SKILL.md` (path supplied by user). Then evaluate:
+
+1. **Frontmatter** — `name` PascalCase or natural-case single word; `description` single-line under ~500 characters with concrete `USE WHEN` triggers; no deprecated fields (`when_to_use`, `triggers:` arrays, `workflows:` arrays).
+
+2. **Description triggers** — concrete user phrases that should fire the skill ("create a hook", "validate plugin"); imperative third-person form ("This skill should be used when…"); not vague ("for skill management"); appropriate length 50–500 characters.
+
+3. **Body content** — body word count ideally 1 000–3 000 (lean focus); imperative voice ("To do X, do Y"); clear sections; concrete guidance over abstract advice; one H1 matching `name:`.
+
+4. **Progressive disclosure** — lean `SKILL.md` with reference material in `@`-included companion files or in `references/`/`examples/`/`scripts/` directories; the body should reference these resources explicitly rather than embedding them inline.
+
+5. **Supporting files** — if `references/`, `examples/`, `scripts/` directories exist, validate that contents are relevant, complete, and that `SKILL.md` points at them. Flag broken file references.
+
+6. **Anti-patterns** — vague trigger descriptions, second-person voice in the description, content bloat that should live in companion files, missing examples when concrete demonstrations would help, broken `@` includes.
+
+Categorize each finding as **critical** (blocks the skill from working), **major** (significantly degrades effectiveness), or **minor** (polish item). For description rewrites, provide both the diagnosis and a concrete proposed rewrite — never just "improve the description".
+
+## Output Format
+
+```markdown
+## Skill Review: [skill-name]
+
+### Summary
+Overall assessment, body word count, top issue.
+
+### Description Analysis
+**Current:** [quote]
+**Issues:** bullet list
+**Recommendations:** specific fixes; suggested improved description verbatim
+
+### Content Quality
+- **Word count:** [N] ([too long / good / too short])
+- **Style:** imperative / mixed / second-person
+- **Organization:** [one-line assessment]
+- **Issues / Recommendations:** bullets
+
+### Progressive Disclosure
+- **Structure:** SKILL.md [N] words; companion files [N]; references/ [N]; examples/ [N]; scripts/ [N]
+- **Assessment:** is the disclosure pattern effective?
+- **Recommendations:** moves, splits, additions
+
+### Specific Issues
+#### Critical ([count]) — file/location: issue → fix
+#### Major ([count])
+#### Minor ([count])
+
+### Positive Aspects
+- what's done well
+
+### Overall Rating
+Pass / Needs Improvement / Needs Major Revision
+
+### Priority Recommendations
+1. highest-priority fix
+2. second
+3. third
+```
+
+## Constraints
+
+- Read the target skill before reporting; do not infer quality from filenames or directory structure alone
+- Cap initial findings at the top three critical/major issues; do not pad with stylistic noise
+- For description rewrites, supply the rewrite verbatim — never "make the description more specific" without showing how
+- Edge cases: a perfect skill gets a brief pass with minor enhancements only; a new minimal skill gets constructive building guidance, not severity flags; a skill > 5 000 words gets a strong split-into-companion-files recommendation; missing referenced files report errors with specific paths
+- When working alongside other reviewers (BuildSkill, BuildAgent), stay focused on skill quality concerns

--- a/rules/KnownIssues.md
+++ b/rules/KnownIssues.md
@@ -5,3 +5,5 @@ Obsidian Linter auto-formats frontmatter between read and write, causing "file m
 `ekctl` (EventKit CLI) and other data-gathering tools (slackdump, DiscordChatExporter.Cli, sqlite3, m365) are pre-approved in `sandbox.excludedCommands` in both `settings.json` and `settings.local.json`. macOS TCC permissions are separate and must also be granted for EventKit tools.
 
 Subagents spawned with `mode: 'auto'` cannot write to git submodule paths even with `bypassPermissions`. Symptom: agent reports completion but no files were created. Workaround: do the writes from the parent session, or accept the permission prompt manually when it surfaces.
+
+Homebrew's `pip3` on macOS enforces PEP 668 strictly — `pip3 install`, `pip3 install --user`, and `pip3 install --break-system-packages` all fail with "No virtual environment found." Use `uv venv <dir>` to create an isolated environment, then `uv pip install --python <dir>/bin/python <package>`. Don't keep retrying pip flags; the wrapper rejects all of them by design.

--- a/rules/SkillNaming.md
+++ b/rules/SkillNaming.md
@@ -1,3 +1,7 @@
 Skill names are two words in PascalCase — scope + focus (BuildSkill, VersionControl, MarkdownSchema). The pair is self-routing: scan by prefix, understand by suffix. Single words are too vague to route or too opaque to discover.
 
 Exceptions: product names already unambiguous on their own (RTK, M365).
+
+No foreign-language words in skill names. Locale context is implied by the parent module (a skill in `forge-finance` is implicitly Czech). Use English or international standard acronyms — `PaymentQr` not `QrPlatba`, `TaxFiling` not `DanovePriznani`. Czech (or other locale-specific) keywords belong in the `description` USE WHEN list for search, not in the skill name itself.
+
+Names must also be self-explanatory in English to a reader unfamiliar with the domain. Avoid technical acronyms in the name unless universally recognized (HTML, JSON, CSV, API). `SpaydQr` is too opaque — most readers don't know SPAYD; `PaymentQr` reads cleanly. Put the obscure acronym in the description and skill body, not in the directory name.

--- a/skills/BuildSkill/CreateWorkflow.md
+++ b/skills/BuildSkill/CreateWorkflow.md
@@ -22,6 +22,7 @@ Follow the structure from [SkillStructure.md](SkillStructure.md).
 - [ ] No unnecessary complexity — minimum needed for the task
 - [ ] If module skill: SKILL.yaml sidecar with `sources:` field (see [CanonSidecar.md](CanonSidecar.md))
 - [ ] Skill listed in module's `defaults.yaml` under each target provider (see [MultiProviderRouting.md](MultiProviderRouting.md))
+- [ ] If locale-specific (e.g., Czech tax): description mixes English action phrases ("record transaction", "validate balance") with backticked native terms (`účetní deník`, `bilance`). Avoid diacritic-stripped czenglish (`podvojne ucetnictvi`) — matches neither natural English nor natural Czech queries
 
 ## Step 3: Create the skill directory and file
 
@@ -41,6 +42,7 @@ For other providers: run `make install` from the module's Makefile.
 
 1. Test invocation: does the description trigger correctly?
 2. Review: does the procedure work end-to-end?
+3. Dispatch the **SkillReviewer** agent on the new `SKILL.md` (and any companion files). It catches trigger weaknesses, czenglish descriptions, broken cross-references, body bloat, and convention drift that self-review misses. Apply confirmed fixes before declaring done.
 
 ## Step 6: Pressure test
 

--- a/skills/BuildSkill/SkillStructure.md
+++ b/skills/BuildSkill/SkillStructure.md
@@ -10,7 +10,29 @@ A skill is a directory under `skills/` containing `SKILL.md` as the entrypoint (
 | `user/`       | Qualifier directory, flattened at assembly     |
 | `@` includes  | Companion file references, resolved by forge    |
 
-**`@` includes vs plain references**: use `@File.md` only for companions that should be auto-injected alongside SKILL.md on every invocation. For optional or variant companions (e.g. a multi-mode skill where only one mode is loaded per run), use plain filename references like `` `File.md` `` and let the AI load on demand. Over-use of `@` wastes tokens on unused companions.
+**`@` includes vs plain references**: use `@File.md` only for companions that should be auto-injected alongside SKILL.md on every invocation. For optional or variant companions (e.g. a multi-mode skill where only one mode is loaded per run), use plain filename references like `` `File.md` `` and let the AI load on demand. Over-use of `@` wastes tokens on unused companions. Never mix the forms.
+
+```markdown
+GOOD — always-loaded reference (forge inlines content into SKILL.md at parse time)
+@SkillStructure.md
+
+GOOD — load-on-demand reference (AI reads via Read tool when the workflow needs it)
+See [`Linting.md`](Linting.md) for the full lint pipeline.
+
+GOOD — same companion table, different intent
+| Workflow | Companion           |
+| -------- | ------------------- |
+| Create   | @CreateWorkflow.md   |       <- always inline
+| Validate | `ValidateWorkflow.md` |     <- load on demand
+
+BAD — `@` inside a markdown link reads as "auto-inject", looks like a regular link, behaves like neither
+[@File.md](File.md)
+
+BAD — `@` on a multi-mode router; every variant inlines on every invocation, defeating routing
+@FantasyMode.md
+@SciFiMode.md
+@NoirMode.md
+```
 
 ## SKILL.md frontmatter
 

--- a/skills/FrontendDesign/SKILL.md
+++ b/skills/FrontendDesign/SKILL.md
@@ -34,6 +34,7 @@ Match implementation complexity to the vision: maximalist designs get elaborate 
 
 - Overused font families (Inter, Roboto, Arial, system fonts, Space Grotesk — don't converge on "safe" choices across generations)
 - Cliched color schemes (purple gradients on white is the canonical offender)
+- Charity/wellness clichés — cream backgrounds with forest green and warm orange/terracotta accents read as spa-yoga-retreat, undermine credibility for donor-facing, institutional, or business audiences. For serious contexts, default to editorial palettes (white + hard black + one decisive accent)
 - Predictable layouts and component patterns
 - Cookie-cutter design that lacks context-specific character
 
@@ -46,3 +47,4 @@ No two designs should be the same. Vary themes (light/dark), fonts, aesthetics a
 - Produce real, working code — HTML/CSS/JS, React, Vue, etc. — not mockups
 - Maintain a single aesthetic point-of-view across the whole output; do not mix brutalist typography with pastel gradients
 - Accessibility and performance are not aesthetic concessions; they are part of production-grade
+- Iterate one visual variable per round when refining a design with the user. Bundling changes (illustration + color logic + label edits in one push) forces the user to accept or reject the whole package; they can't keep the parts that landed and discard the parts that didn't. This costs at least one extra round per bundle.

--- a/skills/LearnFrom/SKILL.md
+++ b/skills/LearnFrom/SKILL.md
@@ -17,9 +17,11 @@ Extract reusable learnings from the current session and apply them as updates to
 
 ## Analyze the Session
 
-**First pass — scan for user-correction signals.** Re-read the conversation specifically looking for: user messages containing "no", "don't", "actually", "wait", "stop", "that's wrong"; follow-up questions that reveal you missed something ("did you X?", "is it still Y?"); user edits or rewrites of your output; requests that imply a prior step should have been done differently. These are the highest-value learnings — they encode behaviors the user actively wants changed. Surface them first.
+**First pass — find the friction points.** Identify each area of the session where work cycled more than once: same problem revisited multiple turns, repeated "still doesn't work" exchanges, user pushback on the same theme across several messages, debugging loops that bounced between hypotheses. List the 1-3 biggest friction zones explicitly by topic ("QR code validation", "visual styling", "Python env"). Each friction zone is a learning gold mine — the cycling itself proves a missing rule, skill, or workflow guard would have prevented it. Skipping friction zones in favor of small surface fixes (a typo, a flag) is the most common LearnFrom failure mode. For each friction zone, ask: what specific instruction, if it had existed at session start, would have collapsed the cycle to one turn?
 
-**Second pass — walk the scan checklist below.** Walk through each category and list concrete findings before filtering.
+**Second pass — scan for user-correction signals.** Re-read the conversation specifically looking for: user messages containing "no", "don't", "actually", "wait", "stop", "that's wrong"; follow-up questions that reveal you missed something ("did you X?", "is it still Y?"); user edits or rewrites of your output; requests that imply a prior step should have been done differently. These encode behaviors the user actively wants changed; surface them alongside the friction zones.
+
+**Third pass — walk the scan checklist below.** Walk through each category and list concrete findings before filtering.
 
 ### Scan Checklist
 
@@ -29,6 +31,8 @@ Extract reusable learnings from the current session and apply them as updates to
 4. **Cross-tool interactions** — when tool A's output feeds tool B, ordering dependencies, cleanup side effects
 5. **Patterns discovered** — reusable conventions, architectural decisions, workflow improvements
 6. **Process improvements** — better ways to approach tasks discovered during work
+
+Cross-reference against friction zones — items inside a friction zone matter more than isolated ones.
 
 For each finding, apply the reusability test: will this come up again in a different session? If no, skip it. If uncertain, include it: a skipped learning is lost, an extra proposal can be rejected.
 
@@ -41,7 +45,9 @@ Concrete signals you should be editing not creating:
 - Adjacent guidance: existing skill mentions the same tool or workflow
 - Sibling concept: existing rule covers the inverse or a related case
 
-Only create a new file when the learning is genuinely orthogonal to everything that exists. If you find yourself writing a rule shorter than ~3 sentences, it almost certainly belongs as a paragraph in an existing file.
+Only create a new rule or short file when the learning is genuinely orthogonal to everything that exists. If you find yourself writing a rule shorter than ~3 sentences, it almost certainly belongs as a paragraph in an existing file.
+
+**Exception — when friction reveals a missing domain skill, propose a new skill, not a paragraph in a general one.** If the friction zone was about a specific tool, format, protocol, or domain operation that no existing skill covers (Czech SPAYD QR generation, GraphQL schema design, Stripe webhook handling, Apple Numbers automation), the right output is a new skill with reusable scaffolding — templates, validation steps, default config, examples — that prevents the friction next time. A bullet in `SystematicDebug` about "clarify failure mode" still has value, but it's the secondary capture; the primary one is the missing domain skill itself. Trigger conditions: friction took 5+ turns to resolve, the operation has multi-step structure (build → validate → render → verify), and the next user invocation would benefit from `/SkillName` rather than from a rule firing on every session. When in doubt, surface this option to the user alongside the edit-existing proposal so they can pick.
 
 Determine the target artifact. The categorization decision matters — rules cost tokens every session; skills cost tokens only when invoked.
 


### PR DESCRIPTION
## Summary

- **LearnFrom**: scan for repeated debug/iteration cycles first; propose a new domain skill when those cycles reveal one is missing, instead of always editing existing artifacts
- **FrontendDesign**: warn against charity/wellness palette stereotypes (cream + forest green + warm orange) for donor-facing or business audiences; iterate one visual variable per round when refining designs with users
- **KnownIssues**: Homebrew \`pip3\` enforces PEP 668 strictly on macOS — use \`uv venv\`, not pip flags
- **SkillNaming**: no foreign-language words in skill names; no obscure acronyms (\`PaymentQr\` not \`SpaydQr\`); locale is implied by the parent module

## Test plan

- [x] \`make validate\` passes locally
- [ ] Reinstall to \`~/.claude/\` via \`make install\` after merge and verify rules + skills load