### PR TITLE
feat: recommend .worktrees/ in-tree pattern for git worktrees

### DIFF
--- a/rules/GitWorktrees.md
+++ b/rules/GitWorktrees.md
@@ -1,11 +1,11 @@
-Use git worktrees for parallel feature work instead of stashing or switching branches. Each worktree gets its own working directory with a shared `.git` store — no context switching, no stash conflicts.
+Use git worktrees for parallel feature work instead of stashing or switching branches. Each worktree gets its own working directory with a shared `.git` store -- no context switching, no stash conflicts.
 
 ```sh
-git worktree add ../repo-feature feature-branch
-git worktree remove ../repo-feature
+git worktree add .worktrees/feature-branch feature-branch
+git worktree remove .worktrees/feature-branch
 git worktree list
 ```
 
-Worktree directories live alongside the main clone, named `repo-branchname`. Never create worktrees inside the main working tree — they pollute the file listing and confuse tools.
+Worktrees live in `.worktrees/<branch-name>` inside the repo, ignored by `.gitignore`. Add `.worktrees/` to `.gitignore` before creating the first worktree so the parallel checkouts do not appear in `git status` of the main tree. The sibling-directory pattern (`../repo-branchname`) also works but pollutes the parent directory and breaks paths in IDE workspaces and editor projects.
 
 When spawning agents for parallel implementation, use `isolation: "worktree"` so each agent works on an isolated copy without conflicting with the main tree or other agents.


### PR DESCRIPTION
## Summary

Reverses the previous prohibition on in-tree worktrees. The `.worktrees/<branch-name>` pattern (gitignored) is now the preferred placement; sibling directories (`../repo-branchname`) move to the alternative slot.

## Why

- Sibling directories pollute the parent directory and break IDE workspace paths and editor project references
- `.worktrees/` keeps parallel checkouts adjacent to the source they branch from -- easier to discover and clean up
- The directory is gitignored, so `git status` of the main tree stays clean
- Both patterns work for git itself; this is a discoverability and tooling-friendliness call

## What changed

`rules/GitWorktrees.md`:
- Replaces example `git worktree add ../repo-feature` with `git worktree add .worktrees/feature-branch`
- Drops the "Never create worktrees inside the main working tree" prohibition
- Adds the gitignore prerequisite

## Test plan

- [x] Markdown renders correctly
- [x] Agent isolation guidance untouched
- [ ] Verify `forge install` deploys the updated rule cleanly to consumers (some of which already follow the in-tree pattern)
