### PR TITLE
feat: publish six general-purpose code-quality rules

### DIFF
--- a/rules/AvoidDuplication.md
+++ b/rules/AvoidDuplication.md
@@ -1,0 +1,1 @@
+Before writing a new helper, search the file and its neighbors for existing logic that does the same thing. Duplicated workaround code diverges silently when one copy gets fixed and the other does not.

--- a/rules/DeadVariables.md
+++ b/rules/DeadVariables.md
@@ -1,0 +1,1 @@
+When generating code, verify each variable is read by something. A variable that is assigned but never consumed downstream is dead weight -- delete it before committing.

--- a/rules/NestingDepth.md
+++ b/rules/NestingDepth.md
@@ -1,0 +1,1 @@
+Extract to methods instead of nesting. If a block exceeds 3 indentation levels, it belongs in a dedicated method with a name that describes the decision it makes.

--- a/rules/NullableTypeSafety.md
+++ b/rules/NullableTypeSafety.md
@@ -1,0 +1,3 @@
+Negating a nullable type (`!$nullableString`) passes for both `null` and `''`. Use explicit comparisons: `=== null`, `!== null`, `=== ''`.
+
+Static analyzers (Psalm, PHPStan, mypy, Clippy) enforce this distinction. Do not suppress their warnings -- fix the comparison.

--- a/rules/RegexAnchoring.md
+++ b/rules/RegexAnchoring.md
@@ -1,0 +1,3 @@
+Regex patterns that extract security-sensitive values (email addresses, tokens, header fields) must use positional anchors (`$`, `\z`, `^`).
+
+Without anchoring, an input like `"<a@good.com>" <a@evil.com>` matches the attacker-controlled address. Anchor to the end of the string or the specific boundary the format requires.

--- a/rules/TestCorrectness.md
+++ b/rules/TestCorrectness.md
@@ -1,0 +1,1 @@
+Structural assertions (count, type, disposition) are necessary but insufficient. Every test must assert the actual content or value produced, not just that something was produced.


### PR DESCRIPTION
## Summary

Adopts six rules that were authored locally without an upstream pointer. Verified to not collide with existing forge-core, forge-dev, forge-council, or forge-obsidian content (by name and by content phrase).

## Rules added

| Rule                | Theme            | Content                                                                                  |
| ------------------- | ---------------- | ---------------------------------------------------------------------------------------- |
| AvoidDuplication    | refactoring      | Search before writing a new helper; duplicated workaround code diverges silently         |
| DeadVariables       | code quality     | Verify each variable is consumed; delete dead weight before committing                   |
| NestingDepth        | code quality     | Extract methods past 3 indentation levels; the method name describes the decision        |
| NullableTypeSafety  | type safety      | Use explicit `=== null` / `!== null` rather than truthiness on nullable types            |
| RegexAnchoring      | security         | Anchor regex patterns that extract security-sensitive values (emails, tokens, headers)   |
| TestCorrectness     | testing          | Every test must assert content or value, not just that something was produced            |

All are language-agnostic.

## Why forge-core and not forge-dev

forge-core already hosts comparable foundational dev rules (`ExplicitCode`, `VerifyClaims`, `PrepareDataOutsideLoops`, `VariableNames`, `ParameterizedQueries`, `PasswordHashing`, etc.). forge-dev's rules are more specialized (Rust-specific, JavaScript-specific, financial data, etc.). These six fit alongside the existing forge-core foundational set.

## Test plan

- [x] No name collisions across all forge module `rules/` directories
- [x] No content overlap (key phrase grep across all forge modules)
- [x] All files end with a trailing newline (PosixTrailingNewline)
- [x] No tabs (NoTabs)
- [ ] After merge, `forge install` deploys these to consumer modules
- [ ] Downstream consumers remove their local duplicates via re-sync

## Rollout

Six small text additions, no frontmatter, no behaviour change. Safe to merge once review is satisfied.
