### PR TITLE
feat: add staged-files scan mode and output format to SecretScan

### DIFF
--- a/skills/SecretScan/SKILL.md
+++ b/skills/SecretScan/SKILL.md
@@ -28,6 +28,16 @@ gitleaks detect --source . --no-git
 gitleaks detect --source .
 ```
 
+### Scan staged files only
+
+For pre-commit checks where only staged content matters:
+
+```sh
+gitleaks protect --source . --staged --no-banner
+```
+
+`gitleaks protect` (vs `detect`) operates on the working-tree diff and is faster than a full scan when integrated into a pre-commit flow.
+
 ### Baseline known findings
 
 If the repo has historical secrets that have been rotated, create a baseline so future scans only flag new leaks:
@@ -61,10 +71,34 @@ paths = [
 ]
 ```
 
+## Output format
+
+Present findings grouped by severity, never echoing the secret value:
+
+```markdown
+## Secret Scan: <repo>
+
+**Mode**: working tree | staged | history
+**Findings**: <count>
+
+### Critical (must fix before merge)
+- <file>:<line> <rule-id> — short description
+
+### Allowlisted (known safe)
+- <file>:<line> <rule-id> — reason
+
+### Recommendation
+<fix | baseline | allowlist guidance>
+```
+
 ## Constraints
 
+- Never display the actual secret value in scan output — show only rule ID, file, and line
 - Never commit `.env`, credentials, or API keys — even to private repos
-- If gitleaks blocks a commit, fix the leak. Don't bypass with `--no-verify`.
-- Different gitleaks versions detect different patterns. If local passes but CI fails, check version mismatch.
+- If gitleaks is not installed, print the install command (`brew install gitleaks`) and stop — do not partially scan
+- If gitleaks blocks a commit, fix the leak; do not bypass with `--no-verify`
+- Recommend baselining over `--no-verify` for historical secrets that have already been rotated
+- Flag any `.env` file that is not in `.gitignore` as a configuration issue
+- Different gitleaks versions detect different patterns; if local passes but CI fails, check version mismatch
 
 [GITLEAKS]: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
## Summary

Adopts two structural improvements from downstream consumer usage of this skill, plus four new constraints. Vendor-specific pattern catalogues stay downstream — only the generic structural improvements come upstream.

## What's added

### Staged-files scan mode

Adds a "Scan staged files only" subsection under Setup. Documents `gitleaks protect --staged` as an alternative to `gitleaks detect` for pre-commit contexts:

- `detect` walks the working tree (or git history)
- `protect` walks the staged diff only — faster when integrated into pre-commit hooks where only staged content matters

The existing pre-commit hook example at line 47 uses `detect`; the new staged subsection clarifies when `protect` is preferable.

### Output format section

New section between `.gitleaks.toml` and `Constraints`. Defines a structured markdown layout for scan findings grouped by severity:

- Mode (working tree | staged | history)
- Findings count
- Critical (must fix before merge): file:line, rule ID, short description
- Allowlisted (known safe): file:line, rule ID, reason
- Recommendation

Includes an explicit guard against echoing the secret value itself in output.

### New constraints

- **Never display the actual secret value in scan output** (security-critical; previously implicit, now explicit)
- **If gitleaks is not installed, print the install command and stop** rather than partially scanning
- **Recommend baselining over `--no-verify`** for already-rotated historical secrets
- **Flag any `.env` file not in `.gitignore`** as a configuration issue

## What stays downstream

Vendor-specific pattern catalogues (payment processors, auth protocols) and consumer-specific high-risk path lists remain in the downstream skill — they are domain-specific extensions, not generic improvements.

## Test plan

- [x] Existing sections (Setup, Pre-commit hook, .gitleaks.toml) untouched
- [x] No frontmatter changes
- [x] Citation reference link `[GITLEAKS]` preserved at the bottom
- [x] All new code blocks tagged with `sh` or `markdown`
- [ ] After merge, downstream consumers can drop their structural duplicates and inherit

## Rollout

Documentation-only edit to one skill file. No breaking changes. Safe to merge once review is satisfied.
