### PR TITLE
fix: drop positional source from forge install/validate calls

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,7 @@ SCRIPT_SHA="f1fc47c463097005152ff2dcd5c8e57e7bb55d9b8c7a61c5b697fc662aeb5bde"
 if command -v prek >/dev/null 2>&1; then
     prek run --all-files
 elif command -v forge >/dev/null 2>&1; then
-    forge validate .
+    forge validate
 else
     echo ""
     echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,6 @@ repos:
 
           - id: forge-validate
             name: forge validate
-            entry: forge validate .
+            entry: forge validate
             language: system
             pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	@command -v $(FORGE) >/dev/null 2>&1 \
 	    || { echo "forge not found — ask an AI assistant to execute INSTALL.md"; exit 1; }
 	git config core.hooksPath .githooks
-	$(FORGE) install .
+	$(FORGE) install --target ~
 
 validate:
 	@bash .githooks/pre-commit


### PR DESCRIPTION
## Summary

- `Makefile`: `forge install .` → `forge install --target ~`. The new `forge` CLI rejects the positional source argument and uses `--source`/`--target` flags. `--target ~` deploys provider directories under `$HOME`.
- `.githooks/pre-commit`: `forge validate .` → `forge validate`.
- `.pre-commit-config.yaml`: `forge validate .` → `forge validate`.

## Test plan

- [x] `forge validate` runs from the patched pre-commit hook (validation actually executes)
- [x] Makefile recipe parses without 'unexpected argument' error
