### PR TITLE
refactor: rename ForgeAdopt skill to AdoptArtifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- `skills/ForgeAdopt/SKILL.md` — removed the 3–5 initial cap and the skills-only restriction; agents are now eligible for adoption
+- `skills/AdoptArtifact/SKILL.md` — removed the 3–5 initial cap and the skills-only restriction; agents are now eligible for adoption
+- `skills/ForgeAdopt/` renamed to `skills/AdoptArtifact/` for brand-neutral naming
 - CORE-0010 amended — validation is now fully handled by `forge validate .`; there are no module-specific validators.
 - `make test` removed. `make validate` is the single entry point.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,17 +10,17 @@ forge-core documents the **adoption mechanism** — how external content enters 
 
 ## Supply Chain Model
 
-### `ForgeAdopt` contract
+### `AdoptArtifact` contract
 
 Every external adoption must:
 
 1. Fetch upstream content via a commit-pinned raw URL (never a mutable branch reference)
 2. Record the upstream `sha256` digest in a SLSA provenance sidecar under `.provenance/`
 3. Record the deployed file's `sha256` digest in the same sidecar (`subject.digest.sha256`)
-4. List `ForgeAdopt` itself as a build dependency in `resolvedDependencies`
+4. List `AdoptArtifact` itself as a build dependency in `resolvedDependencies`
 5. Preserve copyright / attribution as required by the upstream license
 
-The `skills/ForgeAdopt/SKILL.md` file is the canonical workflow.
+The `skills/AdoptArtifact/SKILL.md` file is the canonical workflow.
 
 ### Sidecar schema
 
@@ -42,10 +42,10 @@ provenance:
                   uri: <commit-pinned-url>
                   digest:
                       sha256: <upstream-sha>
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: <forgeadopt-sha>
+                      sha256: <adoptartifact-sha>
 ```
 
 ### Verification procedure
@@ -59,7 +59,7 @@ forge provenance .      # deployed-vs-sidecar digest match
 
 ## Maintainer Responsibilities
 
-- New adoptions go through `ForgeAdopt` — SHA-pinned URLs, provenance sidecars, attribution footers
+- New adoptions go through `AdoptArtifact` — SHA-pinned URLs, provenance sidecars, attribution footers
 - Pin bumps re-verify the SLSA chain and re-read behavioural content before merging
 - Release tags pin `validate.sh` and schema artifacts so downstream modules' pre-commit hooks have stable hashes to anchor
 
@@ -67,7 +67,7 @@ forge provenance .      # deployed-vs-sidecar digest match
 
 In scope:
 
-- Weaknesses in the `ForgeAdopt` workflow that would allow unverified content to enter the ecosystem
+- Weaknesses in the `AdoptArtifact` workflow that would allow unverified content to enter the ecosystem
 - Missing or falsifiable provenance fields in sidecars
 - Schema or attribution requirements that fail to protect license compliance
 

--- a/agents/.provenance/SkillReviewer.yaml
+++ b/agents/.provenance/SkillReviewer.yaml
@@ -16,7 +16,7 @@ provenance:
                   digest:
                       sha256: 78ac55ddc31dd78227df90029d9c2333bdd97567296ddd4a9b23c090a94fc09a
                 - name: AdoptArtifact
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
                       sha256: 7797fadf85662149c1f94054efc8bcbaa06f44efa185eafbdc07fee9eadfd623
         runDetails:

--- a/docs/decisions/ARCH-0013 Markdown-First Adoption Mechanism.md
+++ b/docs/decisions/ARCH-0013 Markdown-First Adoption Mechanism.md
@@ -45,14 +45,14 @@ The temptation is to scaffold a `forge adopt` CLI with gates, transforms, and an
 ## Considered Options
 
 1. **CLI-first** — ship `forge adopt <url>` as a subcommand from day one with transforms encoded as internal functions. Pattern-guessing before evidence.
-2. **Single monolithic workflow skill** — `/ForgeAdopt` as a standard skill with all transform logic embedded in its body. Simple but bundles unrelated concerns (debranding a vendor reference vs minimizeing pep-talk prose).
-3. **Workflow skill composing per-transform skills as build steps** — `/ForgeAdopt` as the orchestrator; each transform (`/DebrandPrompt`, `/MinimizePrompt`, `/RescopePrompt`, `/AlignPrompt`, `/ExtractPrompt`) is a separate skill invoked as a build step. Transforms become reusable outside adoption and each pins independently in provenance.
+2. **Single monolithic workflow skill** — `/AdoptArtifact` as a standard skill with all transform logic embedded in its body. Simple but bundles unrelated concerns (debranding a vendor reference vs minimizeing pep-talk prose).
+3. **Workflow skill composing per-transform skills as build steps** — `/AdoptArtifact` as the orchestrator; each transform (`/DebrandPrompt`, `/MinimizePrompt`, `/RescopePrompt`, `/AlignPrompt`, `/ExtractPrompt`) is a separate skill invoked as a build step. Transforms become reusable outside adoption and each pins independently in provenance.
 
 ## Decision Outcome
 
 Chosen option: **workflow skill composing per-transform skills as build steps.**
 
-`/ForgeAdopt` is a standard skill at `skills/ForgeAdopt/SKILL.md`, following the existing skill `.mdschema` ([ARCH-0001](ARCH-0001 Skills Agents and Rules.md), [ARCH-0002](ARCH-0002 Skills Companion Files.md)). It orchestrates a sequence of per-transform skills, each of which is a first-class skill usable independently of adoption.
+`/AdoptArtifact` is a standard skill at `skills/AdoptArtifact/SKILL.md`, following the existing skill `.mdschema` ([ARCH-0001](ARCH-0001 Skills Agents and Rules.md), [ARCH-0002](ARCH-0002 Skills Companion Files.md)). It orchestrates a sequence of per-transform skills, each of which is a first-class skill usable independently of adoption.
 
 ### Input
 
@@ -73,7 +73,7 @@ Companion files (where upstream content is better extracted than inlined) follow
 
 ### Transform skills (build steps)
 
-Each transform is a standalone skill with its own `SKILL.md`, invocable directly on any prompt-shaped content and composable by `/ForgeAdopt` during adoption. Initial vocabulary:
+Each transform is a standalone skill with its own `SKILL.md`, invocable directly on any prompt-shaped content and composable by `/AdoptArtifact` during adoption. Initial vocabulary:
 
 - **`/DebrandPrompt`** — remove hardcoded vendor references; replace with category-level variables where the instruction generalizes
 - **`/MinimizePrompt`** — collapse motivational / marketing / filler prose while preserving directive content
@@ -81,7 +81,7 @@ Each transform is a standalone skill with its own `SKILL.md`, invocable directly
 - **`/AlignPrompt`** — fix indentation, fence language tags, heading depth, and other convention mismatches
 - **`/ExtractPrompt`** — move bulk reference material into `@`-included companion files so the always-loaded content stays lean
 
-v1 note: these transform skills may not all exist at the first adoption. `/ForgeAdopt` v1 can embed transform logic inline while the vocabulary stabilizes; as a transform proves recurring, it extracts into its own skill and subsequent adoptions record it in `resolvedDependencies`. The schema in [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) supports both modes transparently.
+v1 note: these transform skills may not all exist at the first adoption. `/AdoptArtifact` v1 can embed transform logic inline while the vocabulary stabilizes; as a transform proves recurring, it extracts into its own skill and subsequent adoptions record it in `resolvedDependencies`. The schema in [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) supports both modes transparently.
 
 ### What the mechanism does NOT do
 
@@ -102,7 +102,7 @@ v1 note: these transform skills may not all exist at the first adoption. `/Forge
 ## Related Decisions
 
 - [ARCH-0012](ARCH-0012 Community Adoption Strategy.md) — the strategic decision this mechanism implements
-- [ARCH-0001](ARCH-0001 Skills Agents and Rules.md) — the skill artifact class `/ForgeAdopt` and its transform skills belong to
+- [ARCH-0001](ARCH-0001 Skills Agents and Rules.md) — the skill artifact class `/AdoptArtifact` and its transform skills belong to
 - [ARCH-0002](ARCH-0002 Skills Companion Files.md) — companion-file conventions used by `/ExtractPrompt` and adopted skills with extracted content
 - [PROV-0006](PROV-0006 Adoption Metadata in Provenance Sidecars.md) — the sidecar schema that records transform skills as build dependencies
 - [CORE-0001](CORE-0001 Markdown as System Language.md) — the underlying principle that makes skill-first natural

--- a/docs/decisions/PROV-0006 Adoption Metadata in Provenance Sidecars.md
+++ b/docs/decisions/PROV-0006 Adoption Metadata in Provenance Sidecars.md
@@ -98,7 +98,7 @@ All structural fields are [SLSA v1.0][SLSA] standards-defined:
 
 ### The v1 mode: inline transforms
 
-Before individual transform skills exist, `/ForgeAdopt` performs the transforms inline. In that mode, `resolvedDependencies` contains only the upstream entry; the fact that `buildType: https://forge-cli/adopt/v1` records an adoption and the diff shows what changed is sufficient. As transforms extract into skills ([ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md)), subsequent adoptions grow their dependency lists naturally. The schema supports both phases without change.
+Before individual transform skills exist, `/AdoptArtifact` performs the transforms inline. In that mode, `resolvedDependencies` contains only the upstream entry; the fact that `buildType: https://forge-cli/adopt/v1` records an adoption and the diff shows what changed is sufficient. As transforms extract into skills ([ARCH-0013](ARCH-0013 Markdown-First Adoption Mechanism.md)), subsequent adoptions grow their dependency lists naturally. The schema supports both phases without change.
 
 ### Where transform detail and rationale live
 

--- a/skills/AdoptArtifact/SKILL.md
+++ b/skills/AdoptArtifact/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: ForgeAdopt
+name: AdoptArtifact
 description: "Adopt a community skill from an upstream URL into forge. Fetches the source, applies transforms, produces a working SKILL.md with SLSA provenance. USE WHEN adopting a community skill from aitmpl, anthropics/skills, or a similar catalog."
 version: 0.1.0
 argument-hint: <upstream-url>
 allowed-tools: Bash, WebFetch, Read, Write, Edit, Grep, Glob
 ---
 
-# ForgeAdopt
+# AdoptArtifact
 
 Orchestrating workflow for adopting a community skill into forge. Produces a first-class `SKILL.md` with a SLSA provenance sidecar, following the strategy in [ARCH-0012](docs/decisions/ARCH-0012 Community Adoption Strategy.md) and the mechanism in [ARCH-0013](docs/decisions/ARCH-0013 Markdown-First Adoption Mechanism.md).
 
@@ -99,10 +99,10 @@ provenance:
                   uri: <commit-pinned-url>
                   digest:
                       sha256: <upstream-sha256>
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: <ForgeAdopt-sha256>
+                      sha256: <AdoptArtifact-sha256>
         runDetails:
             builder:
                 id: forge-cli
@@ -112,7 +112,7 @@ provenance:
                 startedOn: <iso-8601>
 ```
 
-Every adoption records `ForgeAdopt` itself as a dependency — the orchestrator is a build input. When individual transform skills extract (`DebrandPrompt`, `MinimizePrompt`, etc.), each applied transform adds its own entry under `resolvedDependencies`.
+Every adoption records `AdoptArtifact` itself as a dependency — the orchestrator is a build input. When individual transform skills extract (`DebrandPrompt`, `MinimizePrompt`, etc.), each applied transform adds its own entry under `resolvedDependencies`.
 
 ### 7. Commit
 

--- a/skills/AlignPrompt/SKILL.md
+++ b/skills/AlignPrompt/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Edit, Write
 
 # AlignPrompt
 
-Bring a prompt-shaped document into forge convention without changing its meaning. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `align` transform.
+Bring a prompt-shaped document into forge convention without changing its meaning. Referenced by [AdoptArtifact](../AdoptArtifact/SKILL.md) as the `align` transform.
 
 ## What to fix
 

--- a/skills/BashConventions/.provenance/BashPatterns.md.yaml
+++ b/skills/BashConventions/.provenance/BashPatterns.md.yaml
@@ -15,8 +15,8 @@ provenance:
                   uri: https://raw.githubusercontent.com/davila7/claude-code-templates/d8e7e60f6fa962bd7842ae2a287361b0a6477f6a/cli-tool/components/skills/development/bash-pro/SKILL.md
                   digest:
                       sha256: 6cefe6c36cecc4dee371363744c345e8bb522b8bbda8c635ea9e35e9675290e6
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
                       sha256: bdf75d591841d6267de31ef0eceead4e74d1691596675a8db7f92f54f797beec
         runDetails:

--- a/skills/DebrandPrompt/SKILL.md
+++ b/skills/DebrandPrompt/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Edit, Grep
 
 # DebrandPrompt
 
-Strip vendor and brand references from a prompt-shaped document so the skill generalizes across ecosystems. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `debrand` transform.
+Strip vendor and brand references from a prompt-shaped document so the skill generalizes across ecosystems. Referenced by [AdoptArtifact](../AdoptArtifact/SKILL.md) as the `debrand` transform.
 
 ## What to remove
 

--- a/skills/ExtractPrompt/SKILL.md
+++ b/skills/ExtractPrompt/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Edit, Write
 
 # ExtractPrompt
 
-Move bulk reference material out of `SKILL.md` into companion files referenced with `@` includes. The SKILL.md stays the entrypoint an AI reads to decide behavior; companions load on demand when the AI needs the reference data. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `extract` transform.
+Move bulk reference material out of `SKILL.md` into companion files referenced with `@` includes. The SKILL.md stays the entrypoint an AI reads to decide behavior; companions load on demand when the AI needs the reference data. Referenced by [AdoptArtifact](../AdoptArtifact/SKILL.md) as the `extract` transform.
 
 Follows [ARCH-0002](docs/decisions/ARCH-0002 Skills Companion Files.md).
 

--- a/skills/FrontendDesign/.provenance/SKILL.yaml
+++ b/skills/FrontendDesign/.provenance/SKILL.yaml
@@ -15,8 +15,8 @@ provenance:
                   uri: https://github.com/davila7/claude-code-templates/blob/1deb97c72161528f6b7d84bc5117ae4be2e42735/cli-tool/components/skills/creative-design/frontend-design/SKILL.md
                   digest:
                       sha256: b81e2ff87ed8fa4d6c377ccb127a7254c9e6a77e3ae94f21e6b514f7bb2945a0
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
                       sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
                 - name: AlignPrompt

--- a/skills/MinimizePrompt/SKILL.md
+++ b/skills/MinimizePrompt/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Edit, Write
 
 Cut motivational, marketing, and emphasis-inflated prose from prompt-shaped documents. Preserve the directive content and the facts that make the artifact work.
 
-Aligned with [MVPR-0001](docs/decisions/MVPR-0001 Minimum Viable Prompt.md) and [MVPR-0002](docs/decisions/MVPR-0002 Prompt Minimalization Metrics.md). Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `minimize` transform.
+Aligned with [MVPR-0001](docs/decisions/MVPR-0001 Minimum Viable Prompt.md) and [MVPR-0002](docs/decisions/MVPR-0002 Prompt Minimalization Metrics.md). Referenced by [AdoptArtifact](../AdoptArtifact/SKILL.md) as the `minimize` transform.
 
 ## What to remove
 

--- a/skills/RescopePrompt/SKILL.md
+++ b/skills/RescopePrompt/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Edit, Grep
 
 # RescopePrompt
 
-Narrow a skill's `allowed-tools` frontmatter to the tools the workflow actually invokes. Implicit `"*"` and undeclared scope are treated as bugs. Referenced by [ForgeAdopt](../ForgeAdopt/SKILL.md) as the `rescope` transform.
+Narrow a skill's `allowed-tools` frontmatter to the tools the workflow actually invokes. Implicit `"*"` and undeclared scope are treated as bugs. Referenced by [AdoptArtifact](../AdoptArtifact/SKILL.md) as the `rescope` transform.
 
 ## What to narrow
 

--- a/skills/SecurityBestPractices/.provenance/SKILL.yaml
+++ b/skills/SecurityBestPractices/.provenance/SKILL.yaml
@@ -15,8 +15,8 @@ provenance:
                   uri: https://github.com/davila7/claude-code-templates/blob/72b67369cb085cb416a8bf85b747450a0d716e33/cli-tool/components/skills/security/security-best-practices/SKILL.md
                   digest:
                       sha256: 93222336cbb0e6745f95ce8ca0e2095f7fcdc7fb062d8e4cf0ecb38fa01fe75b
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
                       sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
                 - name: AlignPrompt

--- a/skills/SkillDiscipline/.provenance/SKILL.yaml
+++ b/skills/SkillDiscipline/.provenance/SKILL.yaml
@@ -15,8 +15,8 @@ provenance:
                   uri: https://github.com/davila7/claude-code-templates/blob/af0b99278d2f8b705bdf700f19c3125c05de7ede/cli-tool/components/skills/development/using-superpowers/SKILL.md
                   digest:
                       sha256: 6a4a4159bf8f784672460f0ec438d4f87adecd54413fdde7e5f0fe66eea3855e
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
                       sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
                 - name: AlignPrompt

--- a/skills/VersionControl/.provenance/GitWorktrees.md.yaml
+++ b/skills/VersionControl/.provenance/GitWorktrees.md.yaml
@@ -15,8 +15,8 @@ provenance:
                   uri: https://raw.githubusercontent.com/davila7/claude-code-templates/d8e7e60f6fa962bd7842ae2a287361b0a6477f6a/cli-tool/components/skills/development/using-git-worktrees/SKILL.md
                   digest:
                       sha256: 4e2aeeb740335d9160ee3a6da66ca6b2ceea8e1e03b9835b5ee357a17500f2bc
-                - name: ForgeAdopt
-                  uri: forge-core/skills/ForgeAdopt/SKILL.md
+                - name: AdoptArtifact
+                  uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
                       sha256: bdf75d591841d6267de31ef0eceead4e74d1691596675a8db7f92f54f797beec
         runDetails:


### PR DESCRIPTION
## Summary

- Renames `skills/ForgeAdopt/` to `skills/AdoptArtifact/` to drop the forge-branded prefix and match the brand-neutral naming used by sibling Prompt skills.
- Updates all source-tree cross-references: sibling skills' `Referenced by` lines, the orchestrator's own SKILL.md heading and embedded provenance example, SECURITY.md sidecar contract, ADRs [ARCH-0013](docs/decisions/ARCH-0013%20Markdown-First%20Adoption%20Mechanism.md) and [PROV-0006](docs/decisions/PROV-0006%20Adoption%20Metadata%20in%20Provenance%20Sidecars.md), and CHANGELOG `[Unreleased]`.
- Refreshes provenance sidecars in `BashConventions`, `FrontendDesign`, `SecurityBestPractices`, `SkillDiscipline`, `VersionControl`, and the `SkillReviewer` agent so the `name:` and `uri:` fields point at the new path. The recorded `sha256` digests stay as historical records of the orchestrator at adoption time and will refresh on the next `forge install`.
- Resolves the inconsistency in `agents/.provenance/SkillReviewer.yaml` where `name: AdoptArtifact` was already paired with `uri: forge-core/skills/ForgeAdopt/SKILL.md`, and matches the existing `AdoptArtifact` references in `skills/ProvenanceAudit/SKILL.md` and `rules/CrossProviderAssembly.md`.

## Test plan

- [x] `rtk forge validate .` returns exit 0; only pre-existing DRIFT lines on `skills/.mdschema` and `.githooks/pre-commit` (unrelated to this rename) appear.
- [x] `rtk grep -rn ForgeAdopt --exclude-dir=build --exclude-dir=.git .` returns only the intentional CHANGELOG rename note.
- [x] `rtk git diff --stat main` shows the directory rename as a single `{ForgeAdopt => AdoptArtifact}` entry — git detected the move.
- [ ] Post-merge: run `forge install` to regenerate `~/.claude/` and prune the stale `~/.claude/skills/AdoptArtifact/` deployment from before the rename existed in source.