### PR TITLE
chore: refresh source provenance and clarify two-layer policy

### DIFF
--- a/.githooks/.provenance/pre-commit.yaml
+++ b/.githooks/.provenance/pre-commit.yaml
@@ -3,7 +3,7 @@ provenance:
     subject:
         - name: .githooks/pre-commit
           digest:
-              sha256: aaa2ebe74042b0f2f0169bf8587c1728d579b1223c3ec6f42e73e90f88ae4ed1
+              sha256: 87ec1f5151495b1e0322341ced833d14b6801212c592e2196be0345707f1abc4
     predicateType: https://slsa.dev/provenance/v1
     predicate:
         buildDefinition:

--- a/agents/.provenance/SkillReviewer.yaml
+++ b/agents/.provenance/SkillReviewer.yaml
@@ -18,7 +18,7 @@ provenance:
                 - name: AdoptArtifact
                   uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: 7797fadf85662149c1f94054efc8bcbaa06f44efa185eafbdc07fee9eadfd623
+                      sha256: f672615fffe1b219d4b8200fc8e105d260bd4a1c4ba355e0a3543be9fe2373ef
         runDetails:
             builder:
                 id: forge-cli

--- a/rules/DeployManifest.md
+++ b/rules/DeployManifest.md
@@ -1,4 +1,8 @@
-The manifest is created when files land at the target — whether via `forge deploy` (from `build/`) or `forge copy` (direct from source). It lives at the target as a `.manifest` dotfile. Provenance sidecars are created by the assembly step and live in `build/`. Never conflate the two — they answer different questions:
+Manifest and provenance answer different questions:
 
-- **Provenance**: "what sources produced this built file?" (build record, assembly step)
-- **Manifest**: "was this deployed file modified since we last put it there?" (deployment record, deploy or copy step)
+- **Provenance**: "what produced this file?"
+- **Manifest**: "was this deployed file modified since we last put it there?"
+
+The manifest is created when files land at the target, whether via `forge deploy` (from `build/`) or `forge copy` (direct from source). It lives at the target as a `.manifest` dotfile.
+
+Provenance lives at two layers. Source-side `.provenance/` records adoption (`adopt/v1`): upstream URL, pinned commit, transform skills applied. Build-side `build/<provider>/.provenance/` records assembly (`assemble/v1`), regenerated on every install.

--- a/skills/.provenance/.mdschema.yaml
+++ b/skills/.provenance/.mdschema.yaml
@@ -3,7 +3,7 @@ provenance:
     subject:
         - name: skills/.mdschema
           digest:
-              sha256: 6b7e7a30c6c6ce613f60997a7dec5520b6fac000a3fea8d1258138cf01504b41
+              sha256: 8037ade9a7b7cc00f5ad717b54a68a26ed5553dd1969389472561cac1e162d20
     predicateType: https://slsa.dev/provenance/v1
     predicate:
         buildDefinition:

--- a/skills/BashConventions/.provenance/BashPatterns.md.yaml
+++ b/skills/BashConventions/.provenance/BashPatterns.md.yaml
@@ -18,7 +18,7 @@ provenance:
                 - name: AdoptArtifact
                   uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: bdf75d591841d6267de31ef0eceead4e74d1691596675a8db7f92f54f797beec
+                      sha256: f672615fffe1b219d4b8200fc8e105d260bd4a1c4ba355e0a3543be9fe2373ef
         runDetails:
             builder:
                 id: forge-cli

--- a/skills/FrontendDesign/.provenance/SKILL.yaml
+++ b/skills/FrontendDesign/.provenance/SKILL.yaml
@@ -3,7 +3,7 @@ provenance:
     subject:
         - name: skills/FrontendDesign/SKILL.md
           digest:
-              sha256: a0533daaf6235789b6dbdbbdcc14632eb372b1920bd37ced37fa07719fe35d31
+              sha256: 29d9cf4fcef3b5faf7b427ef34256011fef77437d656fa7629f78831306720dd
     predicateType: https://slsa.dev/provenance/v1
     predicate:
         buildDefinition:
@@ -18,19 +18,19 @@ provenance:
                 - name: AdoptArtifact
                   uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
+                      sha256: f672615fffe1b219d4b8200fc8e105d260bd4a1c4ba355e0a3543be9fe2373ef
                 - name: AlignPrompt
                   uri: forge-core/skills/AlignPrompt/SKILL.md
                   digest:
-                      sha256: 1f16a4bd57021cd7802ac1e99975811dd2a749960e5898ebdab50f570bd75f90
+                      sha256: 17377e6a9aa21adbf2609add25efd5f40cfa3c8af1687f31d85f0e41a51ef49a
                 - name: RescopePrompt
                   uri: forge-core/skills/RescopePrompt/SKILL.md
                   digest:
-                      sha256: f9219dd6a0b47d8ffd6aceb2b9e3c3835fe7f7f022c0448d60fb8519322431cd
+                      sha256: 93c671d3189cb4f1f1cd573cd87bfb1d33f8f45ac18d08ec7758b95995a530a1
                 - name: MinimizePrompt
                   uri: forge-core/skills/MinimizePrompt/SKILL.md
                   digest:
-                      sha256: 09cc1baa8e0e25d0514dba717008df249f4ad07ff54b3a318839f69df9a47794
+                      sha256: 813de312acb35aa1b86f88bd36d204a08ea5ee7491bda860583877420d900f1d
         runDetails:
             builder:
                 id: forge-cli

--- a/skills/SecurityBestPractices/.provenance/SKILL.yaml
+++ b/skills/SecurityBestPractices/.provenance/SKILL.yaml
@@ -18,23 +18,23 @@ provenance:
                 - name: AdoptArtifact
                   uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
+                      sha256: f672615fffe1b219d4b8200fc8e105d260bd4a1c4ba355e0a3543be9fe2373ef
                 - name: AlignPrompt
                   uri: forge-core/skills/AlignPrompt/SKILL.md
                   digest:
-                      sha256: 1f16a4bd57021cd7802ac1e99975811dd2a749960e5898ebdab50f570bd75f90
+                      sha256: 17377e6a9aa21adbf2609add25efd5f40cfa3c8af1687f31d85f0e41a51ef49a
                 - name: RescopePrompt
                   uri: forge-core/skills/RescopePrompt/SKILL.md
                   digest:
-                      sha256: f9219dd6a0b47d8ffd6aceb2b9e3c3835fe7f7f022c0448d60fb8519322431cd
+                      sha256: 93c671d3189cb4f1f1cd573cd87bfb1d33f8f45ac18d08ec7758b95995a530a1
                 - name: DebrandPrompt
                   uri: forge-core/skills/DebrandPrompt/SKILL.md
                   digest:
-                      sha256: ff0c248906d89d94be5b7a8a75453d796e72fe9d8698162eaaaaca905eaef016
+                      sha256: 20da971b5a5eba94acae6ccb257b02f8eb2fae86b71dd65e4bd3885c433deaa4
                 - name: MinimizePrompt
                   uri: forge-core/skills/MinimizePrompt/SKILL.md
                   digest:
-                      sha256: 09cc1baa8e0e25d0514dba717008df249f4ad07ff54b3a318839f69df9a47794
+                      sha256: 813de312acb35aa1b86f88bd36d204a08ea5ee7491bda860583877420d900f1d
         runDetails:
             builder:
                 id: forge-cli

--- a/skills/SkillDiscipline/.provenance/SKILL.yaml
+++ b/skills/SkillDiscipline/.provenance/SKILL.yaml
@@ -18,23 +18,23 @@ provenance:
                 - name: AdoptArtifact
                   uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: dda5e9d68b9f46eaa1cca9df5975591ac0f933e49d80716a84417f1cb23bbe0c
+                      sha256: f672615fffe1b219d4b8200fc8e105d260bd4a1c4ba355e0a3543be9fe2373ef
                 - name: AlignPrompt
                   uri: forge-core/skills/AlignPrompt/SKILL.md
                   digest:
-                      sha256: 1f16a4bd57021cd7802ac1e99975811dd2a749960e5898ebdab50f570bd75f90
+                      sha256: 17377e6a9aa21adbf2609add25efd5f40cfa3c8af1687f31d85f0e41a51ef49a
                 - name: RescopePrompt
                   uri: forge-core/skills/RescopePrompt/SKILL.md
                   digest:
-                      sha256: f9219dd6a0b47d8ffd6aceb2b9e3c3835fe7f7f022c0448d60fb8519322431cd
+                      sha256: 93c671d3189cb4f1f1cd573cd87bfb1d33f8f45ac18d08ec7758b95995a530a1
                 - name: DebrandPrompt
                   uri: forge-core/skills/DebrandPrompt/SKILL.md
                   digest:
-                      sha256: ff0c248906d89d94be5b7a8a75453d796e72fe9d8698162eaaaaca905eaef016
+                      sha256: 20da971b5a5eba94acae6ccb257b02f8eb2fae86b71dd65e4bd3885c433deaa4
                 - name: MinimizePrompt
                   uri: forge-core/skills/MinimizePrompt/SKILL.md
                   digest:
-                      sha256: 09cc1baa8e0e25d0514dba717008df249f4ad07ff54b3a318839f69df9a47794
+                      sha256: 813de312acb35aa1b86f88bd36d204a08ea5ee7491bda860583877420d900f1d
         runDetails:
             builder:
                 id: forge-cli

--- a/skills/VersionControl/.provenance/GitWorktrees.md.yaml
+++ b/skills/VersionControl/.provenance/GitWorktrees.md.yaml
@@ -18,7 +18,7 @@ provenance:
                 - name: AdoptArtifact
                   uri: forge-core/skills/AdoptArtifact/SKILL.md
                   digest:
-                      sha256: bdf75d591841d6267de31ef0eceead4e74d1691596675a8db7f92f54f797beec
+                      sha256: f672615fffe1b219d4b8200fc8e105d260bd4a1c4ba355e0a3543be9fe2373ef
         runDetails:
             builder:
                 id: forge-cli


### PR DESCRIPTION
## Summary

- Rewrites [rules/DeployManifest.md](rules/DeployManifest.md) to remove the contradiction with [rules/CrossProviderAssembly.md](rules/CrossProviderAssembly.md). Leads with the manifest-vs-provenance question, then states explicitly that provenance lives at two layers: source-side `.provenance/` for adoption (`adopt/v1`) and build-side `build/<provider>/.provenance/` for assembly (`assemble/v1`).
- Refreshes 20 stale digests across 8 source-side sidecars uncovered by an inventory pass:
  - **Subject drift**: `.githooks/pre-commit`, `skills/.mdschema`, and `skills/FrontendDesign/SKILL.md` had on-disk content that no longer matched their recorded `subject.digest.sha256`.
  - **In-repo dependency drift**: every sidecar referencing `AdoptArtifact` and the transform skill family (`AlignPrompt`, `RescopePrompt`, `DebrandPrompt`, `MinimizePrompt`) now records the current digest. The rename PR (#42) modified the content of those files, invalidating the recorded digests.
- External `upstream` digests are intentionally left as immutable historical records, since they pin a fetched-at-SHA snapshot from the upstream catalog.

## Audit findings

Source provenance coverage is complete. All adopted SKILL.md files (`FrontendDesign`, `SkillDiscipline`, `SecurityBestPractices`) and adopted agent (`SkillReviewer`) have sidecars, as do the two adopted companions (`BashConventions/BashPatterns.md`, `VersionControl/GitWorktrees.md`). Authored skills (`AdoptArtifact`, `ArchitectureDecision`) do not carry sidecars by design.

## Test plan

- [x] `rtk forge validate .` returns exit 0.
- [x] Custom verifier (parses every `.provenance/*.yaml`, recomputes `subject.digest.sha256` against the file the sidecar describes, recomputes `resolvedDependencies[*].sha256` against `forge-core/` paths) reports `stale records: 0`.
- [x] External `upstream` digests are not touched.
- [ ] Post-merge: re-run the verifier on main to confirm clean state, and refresh again if subsequent commits drift further.