### PR TITLE
feat: add StagedReview skill and StageForReview rule

### DIFF
--- a/rules/StageForReview.md
+++ b/rules/StageForReview.md
@@ -1,0 +1,5 @@
+Stage changes (`git add <files>`) but do not commit. The user reviews the staged diff with their preferred tool (`tuicr`, `revdiff`, `git diff --cached`) before the commit lands. Commit only after explicit approval — words like `commit`, `looks good`, `lgtm`, `go`. Pre-commit hooks passing is not approval; they verify correctness, not intent.
+
+For multi-step work, stage incrementally so each step is reviewable on its own rather than as one large diff.
+
+See [StagedReview](../skills/StagedReview/SKILL.md) for the review workflow.

--- a/skills/StagedReview/SKILL.md
+++ b/skills/StagedReview/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: StagedReview
+description: "Review your own staged changes via a code-review TUI before triggering a commit. USE WHEN about to commit, walking through your own staged diff, self-reviewing before approval, tuicr, revdiff, git diff cached."
+version: 0.1.0
+allowed-tools: Bash, Read
+---
+
+# StagedReview
+
+After staging changes with `git add`, walk the diff before committing. Annotate friction points, fix them, restage, re-review.
+
+This skill is paired with the [StageForReview][SFR] rule: agents stage but do not commit; the user reviews the staged set and signals approval; then the commit runs.
+
+## Tools
+
+| Tool                | Strength                                                  | Worktree compatibility |
+|---------------------|-----------------------------------------------------------|------------------------|
+| `tuicr`             | TUI with vim keybindings, GitHub-style annotation export | Limited (see caveat)   |
+| `revdiff`           | TUI with `--staged` flag, in-place annotations           | Limited (see caveat)   |
+| `git diff --cached` | Plain text, universal, no install                         | Full                   |
+
+`tuicr` and `revdiff` are equivalent in role; pick by personal preference. `git diff --cached` is the always-available baseline.
+
+## Flow
+
+1. **Stage**: `git add <files>` by name. Never `-A` or `.`.
+2. **Open the staged diff** with one of:
+    ```sh
+    revdiff --staged                   # purpose-built for the staged set
+    tuicr -w                            # working-tree mode; see `tuicr --help` for revset combos
+    git diff --cached                   # plain text fallback
+    ```
+3. **Annotate** issues in the TUI; export to clipboard or stdout if the tool supports it.
+4. **Fix** issues by editing the affected files. Re-`git add` them.
+5. **Re-review** until clean.
+6. **Approve and commit**. The agent commits only after the user signals approval.
+
+## Worktree caveat
+
+In a git worktree (`.worktrees/<branch>` per [GitWorktrees](../VersionControl/GitWorktrees.md)), the `.git` entry is a file pointing to the parent's `.git/worktrees/<branch>` directory. `tuicr` and `revdiff` can fail to walk this indirection cleanly.
+
+Workarounds:
+
+- **Fall back to `git diff --cached`** in the worktree. Universal and works.
+- **Switch the main checkout to the branch** under review: `git worktree remove .worktrees/<branch>` then `git switch <branch>` in the main checkout. Run the TUI from the main checkout, which has a real `.git` directory.
+- **Run with explicit git paths**: `GIT_DIR=$(git rev-parse --git-dir) GIT_WORK_TREE=$(git rev-parse --show-toplevel) tuicr ...`. Hit-or-miss depending on the tool's internals.
+
+Until upstream support lands, the main-checkout path is the cleanest for non-trivial diffs.
+
+## What to look for during self-review
+
+- Unintended files staged (config dumps, build artifacts, secrets)
+- Comments left as TODO or scratch notes
+- Inconsistent naming across the diff
+- Tests that don't actually assert content (`assert!(result.is_ok())` without checking the value — see [TestCorrectness](../../rules/TestCorrectness.md))
+- Inline duplication of logic that already exists elsewhere ([AvoidDuplication](../../rules/AvoidDuplication.md))
+- Em dashes ([NoEmDash](../../rules/NoEmDash.md))
+
+[SFR]: ../../rules/StageForReview.md

--- a/skills/VersionControl/SKILL.md
+++ b/skills/VersionControl/SKILL.md
@@ -27,9 +27,9 @@ Keep the first line under 72 characters. Add a blank line and body for context w
 
 ## Staging
 
-- Stage specific files by name — never use `git add -A` or `git add .`
-- Review `git diff --staged` before committing
+- Stage specific files by name; never use `git add -A` or `git add .`
 - Never commit files that contain secrets (`.env`, credentials, API keys)
+- Stage and pause for the user to self-review before the commit lands. See [StageForReview](../../rules/StageForReview.md) for the rule, [StagedReview](../StagedReview/SKILL.md) for the review workflow with `tuicr` / `revdiff` / `git diff --cached`.
 
 ## Push Policy
 
@@ -106,6 +106,12 @@ Auto-detect from the remote origin URL. If ambiguous, ask the user.
 - Prefer rulesets over legacy branch protection (GitHub) — rulesets are more granular and support bypass actors
 - Document governance in the repo itself (CODEOWNERS, branch rules) not just in external settings
 - Always read current rules before modifying — audit first, change second
+
+## Commit Signing
+
+SSH-format signing with FIDO2 hardware keys (YubiKey, etc.) plus macOS-specific gotchas around Apple's bundled `ssh-agent`.
+
+@CommitSigning.md
 
 ## Parallel Work
 


### PR DESCRIPTION
## Summary

- Adds `rules/StageForReview.md` — a directive that AI agents must `git add` staged changes but pause for the user to review the staged diff before any commit. Approval words (`commit`, `looks good`, `lgtm`, `go`) unlock the commit step. Pre-commit hooks passing is not approval.
- Adds `skills/StagedReview/SKILL.md` — the review workflow. Documents `tuicr`, `revdiff`, and `git diff --cached`. Covers the git-worktree gotcha (cd into the worktree before invoking the TUIs). Lists what to look for during self-review.
- `skills/VersionControl/SKILL.md` Staging section gains links to both so users land at the workflow via the existing git-conventions entry point.

## Test plan

- [x] Both files lint clean against existing mdschema
- [x] Self-tested in the forge-cli PR #50 session: I staged the dotforge implementation, paused for the user to review via tuicr, the user approved, the commit landed. The flow works.

## Why now

The pattern emerged organically across recent forge-cli work. We needed a rule to lock it in so future sessions follow the same pattern without re-deriving it each time.
