### PR TITLE
chore: rename InstallMd rule, VersionControl + SettingsMaintenance updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,7 @@ Deploy forge-core skills, agents, and rules to all AI providers via Makefile.
 - Claude Code (or another AI provider CLI)
 - Rust toolchain (`rustup` + `cargo`) — [rustup.rs](https://rustup.rs)
 - forge-cli (`cargo install` from source, see step below)
+- gitleaks (`brew install gitleaks`) — shared by SecretScan, VersionControl, and ForensicAgent
 
 Without Rust: copy `skills/`, `agents/`, `rules/` into the provider config directory (e.g., `~/.claude/`) directly.
 
@@ -73,9 +74,13 @@ make install
 
 ### Wire Claude Code hooks
 
-`forge install` deploys skills, agents, and rules, but not hooks. Claude Code hooks must be wired manually into `~/.claude/settings.json`.
+**Plugin users:** hooks are auto-discovered from `hooks/hooks.json` when forge-core is installed as a Claude Code plugin (`claude plugins add`). No manual wiring needed.
 
-Read `hooks/hooks.json` in this repository: it lists every hook, its event, matcher, and command. For each entry, add a corresponding record to the `hooks` key in `~/.claude/settings.json`, replacing `${CLAUDE_PLUGIN_ROOT}` with the absolute path to your clone.
+**forge-install users:** `forge install` deploys skills, agents, and rules, but not hooks. Read `hooks/hooks.json` in this repository and add a corresponding record for each hook to `~/.claude/settings.json`, replacing `${CLAUDE_PLUGIN_ROOT}` with the absolute path to your clone.
+
+### Per-skill configuration
+
+Some skills require user-config files the plugin system cannot create. Check for an `INSTALL.md` inside each skill directory (e.g., `skills/VersionControl/INSTALL.md`) and follow its setup steps after the module install.
 
 ### Verify skill deployment
 

--- a/docs/decisions/NAME-0001 Forge Naming Collisions.md
+++ b/docs/decisions/NAME-0001 Forge Naming Collisions.md
@@ -1,0 +1,93 @@
+---
+title: "Forge Naming Collisions"
+description: "Inventory of other CLIs named 'forge' and the chosen ~/.config/forge/ coexistence pattern"
+type: adr
+category: architecture
+tags:
+    - architecture
+    - ecosystem
+    - naming
+status: accepted
+created: 2026-05-25
+updated: 2026-05-25
+author: "@N4M3Z"
+project: forge-core
+related:
+    - "ARCH-0008 Multi-Provider Support.md"
+responsible: ["@N4M3Z"]
+accountable: ["@N4M3Z"]
+consulted: []
+informed: []
+upstream: []
+---
+
+# Forge Naming Collisions
+
+## Context and Problem Statement
+
+The name `forge` is crowded across the developer-tools ecosystem. A user who installs forge-cli alongside other `forge`-named tools shares both the `forge` binary name on `$PATH` and, potentially, the `~/.config/forge/` directory. Before forge artifacts started reading per-user runtime data from `~/.config/forge/<artifact>.{ext}` (see [UserConfig][UC] rule), the convention needed to be checked against tools already claiming that path.
+
+## Decision Drivers
+
+- Avoid silent filesystem collisions with established tools
+- Preserve a clean user experience for the common case (user has only forge-cli installed)
+- Follow XDG Base Directory Spec — `~/.config/<tool>/` is the canonical home for a tool literally named `<tool>`
+- Leave room for forge-cli itself to grow XDG-aware settings later
+
+## Considered Options
+
+1. **`~/.config/forge/` with reserved `config*` filenames** — Canonical XDG. Coexists file-by-file with [git-pkgs/forge][GP] (which owns the literal filename `config`). forge-cli artifacts use artifact-named files (`forensic.yaml`, `avatar.yaml`); no overlap. Reservation of `config*` keeps the door open for forge-cli's own settings.
+2. **`~/.config/forge.d/`** — Subdirectory marker. Zero collision risk but non-standard; XDG tools normally use plain `~/.config/<name>/`.
+3. **`~/.config/forge-framework/`** — Fully branded. No collision risk, but verbose and drifts from the binary name.
+
+## Decision Outcome
+
+Chosen option: **`~/.config/forge/` with reserved `config*` filenames**. Documented in the [UserConfig][UC] rule. Artifact filenames must never start with `config`.
+
+## Existing tools named `forge`
+
+| Tool | Purpose | Config path | Collision with our convention |
+| ---- | ------- | ----------- | ----------------------------- |
+| [forge-cli][FC] | Module dispatcher and skill assembler for AI coding tools (this project) | `<module>/defaults.yaml`, `<module>/config.yaml`, and now `~/.config/forge/<artifact>.{ext}` | n/a — this is the convention |
+| [git-pkgs/forge][GP] | Go-based unified CLI for GitHub/GitLab/Gitea/Forgejo | `~/.config/forge/config` (INI, respects `$XDG_CONFIG_HOME`) | Same directory, different filename. Coexists because `config*` is reserved on our side. |
+| [Foundry `forge`][FD] | Ethereum/Solidity build, test, and deployment tool. Largest user base of any `forge` binary. | `~/.foundry/foundry.toml` (global) plus `foundry.toml` per project. Override via `FOUNDRY_CONFIG`. | No filesystem collision. Binary-name collision on `$PATH` resolves via PATH ordering. |
+| [ForgeCode (`@antinomyhq/forge`)][AN] | AI pair programmer distributed via npm | `~/forge/.forge.toml`, optional `$FORGE_CONFIG` override | No filesystem collision. Binary `forge` on `$PATH` collides; rename or alias on the user's side. |
+| [Homebrew `forge`][HB] | ArrayFire visualization C++ library (not a CLI with config) | none | None. |
+| [Atlassian Forge CLI (`@forge/cli`)][AF] | Build tool for Atlassian apps | per-project node config | None. |
+| Electron Forge | Build pipeline for Electron apps | per-project `forge.config.js` | None. |
+| Laravel Forge CLI | Server provisioning client for Laravel SaaS | per-project + API tokens via login flow | None. |
+| Autodesk Forge CLI | Autodesk Platform Services client | per-project, env vars | None. |
+| AUR `foundry-bin` | Distribution channel for Foundry on Arch | same as Foundry | same as Foundry |
+| AUR `forge-code-bin` | Distribution channel for ForgeCode on Arch | same as ForgeCode | same as ForgeCode |
+
+### Consequences
+
+- [+] Users with `git-pkgs/forge` installed can also use forge-cli without collisions. Each tool reads only files it owns.
+- [+] Convention follows XDG; no special-snowflake path to document.
+- [+] Future forge-cli XDG settings can land at `~/.config/forge/config.{toml,yaml}` without breaking existing artifacts.
+- [-] Binary-name collision with Foundry persists on `$PATH`. Users running both must resolve via PATH ordering, an alias, or by renaming one of the binaries. This is outside the scope of the config convention.
+- [-] git-pkgs/forge users may briefly wonder why two unrelated tools share the directory. Documented here so the answer exists.
+
+## Related Decisions
+
+- [UserConfig][UC] — establishes the per-artifact-file convention inside `~/.config/forge/`
+- [ARCH-0008](ARCH-0008 Multi-Provider Support.md) — establishes how forge modules deploy across providers; the user-config convention complements deployment with a per-user-machine layer
+
+## Links
+
+- [forge-cli][FC] — this project
+- [git-pkgs/forge][GP] — Git provider CLI, uses `~/.config/forge/config`
+- [Foundry config reference][FD] — `~/.foundry/foundry.toml`
+- [ForgeCode FORGE_CONFIG docs][AN] — `~/forge/.forge.toml`
+- [Homebrew formula `forge` (ArrayFire)][HB]
+- [Atlassian Forge CLI reference][AF]
+- [XDG Base Directory Spec][XDG]
+
+[UC]: ../../rules/UserConfig.md
+[FC]: https://github.com/N4M3Z/forge-cli
+[GP]: https://github.com/git-pkgs/forge
+[FD]: https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md
+[AN]: https://forgecode.dev/docs/forge-config/
+[HB]: https://formulae.brew.sh/formula/forge
+[AF]: https://developer.atlassian.com/platform/forge/cli-reference/
+[XDG]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/rules/InstallInstructions.md
+++ b/rules/InstallInstructions.md
@@ -1,0 +1,10 @@
+Every repository ships an `INSTALL.md` at the repo root following the Mintlify install.md standard [MINTLIFY] for agent-executable installation. The file tells AI agents how to install and verify the software without polluting CLAUDE.md (behavioral), AGENTS.md (behavioral), or README.md (human-oriented).
+
+Every skill whose use requires setup beyond its own SKILL.md — wiring a hook, dropping a config file, installing a binary, configuring a service — also ships an `INSTALL.md` next to its `SKILL.md`. Same Mintlify shape. SKILL.md keeps behavioral guidance ("when committing, follow these rules"); INSTALL.md keeps actionable setup ("symlink this script, paste this snippet into settings.json"). Skills with no setup beyond `make install` need no INSTALL.md.
+
+Required elements (both scopes): H1 title, blockquote summary, conversational opening, OBJECTIVE, DONE WHEN (measurable success condition), TODO checklist (3-7 items), detailed steps with shell commands, EXECUTE NOW closing.
+
+DONE WHEN embeds verification — no separate VERIFY.md needed. Template at `templates/init/INSTALL.md` in forge-cli [TEMPLATE].
+
+[MINTLIFY]: https://github.com/mintlify/install-md "Mintlify install.md — standard for LLM-executable installation"
+[TEMPLATE]: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/INSTALL.md "INSTALL.md template"

--- a/rules/InstallMd.md
+++ b/rules/InstallMd.md
@@ -1,8 +1,0 @@
-Every repository ships an `INSTALL.md` following the Mintlify install.md standard [MINTLIFY] for agent-executable installation. The file tells AI agents how to install and verify the software without polluting CLAUDE.md (behavioral), AGENTS.md (behavioral), or README.md (human-oriented).
-
-Required elements: H1 title, blockquote summary, conversational opening, OBJECTIVE, DONE WHEN (measurable success condition), TODO checklist (3-7 items), detailed steps with shell commands, EXECUTE NOW closing.
-
-DONE WHEN embeds verification — no separate VERIFY.md needed. Template at `templates/INSTALL.md` in forge-cli [TEMPLATE].
-
-[MINTLIFY]: https://github.com/mintlify/install-md "Mintlify install.md — standard for LLM-executable installation"
-[TEMPLATE]: https://github.com/N4M3Z/forge-cli/blob/main/templates/INSTALL.md "INSTALL.md template"

--- a/skills/SettingsMaintenance/ClaudeBaseline.md
+++ b/skills/SettingsMaintenance/ClaudeBaseline.md
@@ -26,7 +26,6 @@ Follow the 6-phase workflow from `SKILL.md` (Scope, Inventory, Audit, Report, Ap
         ]
     },
     "env": {
-        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
         "BASH_DEFAULT_TIMEOUT_MS": "180000",
         "BASH_MAX_TIMEOUT_MS": "900000"
     },
@@ -45,11 +44,13 @@ Targets adapted from [Trail of Bits config][TOB]. SSH gets both Read and Edit de
 
 | Var | Value | Rationale |
 |---|---|---|
-| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `"1"` | Documented rollup per [env-vars][ENV]: telemetry, autoupdater, feedback survey, error reporting |
 | `BASH_DEFAULT_TIMEOUT_MS` | `"180000"` | 2 min default per [ENV], bump to 3 min |
 | `BASH_MAX_TIMEOUT_MS` | `"900000"` | 10 min default per [ENV], bump to 15 min |
 
-Excluded by design: `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (no documented numeric default, "varies by model"), `MAX_THINKING_TOKENS` (appears only contextually in the docs). Setting either to a fabricated value risks regressions.
+Excluded by design:
+
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` rolls up telemetry, autoupdater, feedback survey, and error reporting per [env-vars][ENV]. It also blocks the outbound channel Remote Control uses to bridge terminal sessions to claude.ai and the mobile app. Set it only if you do not use Remote Control and accept the autoupdater opt-out.
+- `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (no documented numeric default, "varies by model") and `MAX_THINKING_TOKENS` (appears only contextually in the docs). Setting either to a fabricated value risks regressions.
 
 ## Model pin
 

--- a/skills/VersionControl/INSTALL.md
+++ b/skills/VersionControl/INSTALL.md
@@ -1,0 +1,52 @@
+# Safety Net
+
+> Create the safety-net config file so the hook can block AI-initiated commits containing PII, deprecated identifiers, or other user-defined patterns.
+
+I want you to set up the safety-net pre-commit gate for me. Execute all the steps below autonomously.
+
+## OBJECTIVE
+
+Create `~/.config/forge/safety-net` (one extended regex per line) so the `safety-net` Claude Code hook, auto-discovered from forge-core's `hooks/hooks.json`, blocks commits that match any pattern.
+
+## DONE WHEN
+
+Staging a file containing a pattern from `~/.config/forge/safety-net` and attempting `git commit` inside Claude Code triggers a block decision from the safety-net hook.
+
+## TODO
+
+- [ ] Create `~/.config/forge/` directory
+- [ ] Create `~/.config/forge/safety-net` with initial patterns
+- [ ] Verify the hook fires on a test commit
+
+## Steps
+
+### Create the config directory
+
+```sh
+mkdir -p ~/.config/forge
+```
+
+### Create the safety-net config
+
+One extended regex per line, `#` comments allowed. Include anything that must never enter any repo: deprecated emails, personal phones, internal hostnames, legacy handles, vendor names.
+
+```sh
+touch ~/.config/forge/safety-net
+```
+
+Populate with your patterns. This file lives in the private dotfiles repo and deploys to every machine.
+
+### Verify
+
+1. Stage a test file containing a string that matches one of your patterns
+2. Attempt `git commit` inside Claude Code
+3. The safety-net hook should emit a block decision with a match count
+4. Unstage the test file after confirming
+
+### Prerequisites
+
+The safety-net hook is auto-discovered when forge-core is installed as a Claude Code plugin. No manual hook wiring needed.
+
+gitleaks (Layer 1 of the pre-commit gates) is a shared module prerequisite documented in the [module INSTALL.md](../../INSTALL.md).
+
+EXECUTE NOW: Complete the above TODO list to achieve: a staged commit containing a safety-net pattern triggers a block.

--- a/skills/VersionControl/SKILL.md
+++ b/skills/VersionControl/SKILL.md
@@ -33,57 +33,37 @@ Keep the first line under 72 characters. Add a blank line and body for context w
 
 ## Pre-commit Gates
 
-Every repo runs two stacked gates: gitleaks (categorical, pattern-based) and a known-dangerous-strings grep (specific, user-curated). gitleaks alone misses anything that doesn't match its built-in rules — legacy email addresses, retired internal hostnames, an old phone number — because those look like ordinary text. The user knows them; encode that knowledge in the hook.
+Two stacked gates protect against leaking PII or secrets into git history. Both must pass before a commit lands.
 
-### Layer 1: gitleaks
+**Layer 1 — gitleaks.** Categorical scanner for API tokens, private keys, connection strings. Fires via the repo's `.githooks/pre-commit` for user-typed commits. See [SecretScan](../SecretScan/SKILL.md) for `.gitleaks.toml` and baseline workflow.
 
-See the [SecretScan](../SecretScan/SKILL.md) skill for install, `.gitleaks.toml`, and baseline workflow. This is the categorical layer — API tokens, private keys, connection strings.
+**Layer 2 — safety-net.** A user-curated regex list at `~/.config/forge/safety-net` (per the [UserConfig](../../rules/UserConfig.md) rule) catches everything gitleaks misses: deprecated emails, personal phones, internal hostnames, legacy handles. The `safety-net` Claude Code hook (`hooks/safety-net.sh`, auto-discovered via `hooks.json`) intercepts AI-initiated `git commit` calls, walks staged blobs, and emits a block decision on any match. CI runs the same regex check as second-line defense.
 
-### Layer 2: known-dangerous strings
+### Which layer owns what
 
-Maintain a per-user list of literal strings that must never enter any repo. Typical entries:
+| Pattern type                                | Layer      | Why                                            |
+| ------------------------------------------- | ---------- | ---------------------------------------------- |
+| API keys, tokens, private key blocks        | gitleaks   | Categorical rules updated by the community     |
+| Credentials in `.env` or config files       | gitleaks   | Pattern-based detection                        |
+| User-specific identifiers (emails, phones)  | safety-net | Only you know what's dangerous for you         |
+| Deprecated addresses, legacy handles        | safety-net | Not in any public rule database                |
 
-- Deprecated email addresses (`@protonmail.com`, `@me.com`, old company addresses)
-- Retired internal hostnames or IPs
-- Personal phone numbers in any format
-- Legacy handles or usernames you no longer want indexed
+When in doubt, add to safety-net. gitleaks rules evolve upstream; safety-net patterns are yours to control.
 
-Keep the list at `~/.config/git/danger-strings` (plain text, one regex per line, `#` comments allowed). Manage it alongside dotfiles so the same list deploys to every machine.
+### When a gate blocks
 
-```text
-# ~/.config/git/danger-strings — extended regex, one per line
-@protonmail\.(com|ch)
-@me\.com
-\b\+420[\s-]?\d{3}[\s-]?\d{3}[\s-]?\d{3}\b
-oldhost\.internal\.example
-```
+1. Read the block reason (match count, config path)
+2. Inspect the staged diff to find the offending lines
+3. Fix the content, re-stage, and retry
+4. If it's a false positive (test fixture, inert example), update `~/.config/forge/safety-net` to exclude the pattern or add the file to `.gitleaks.toml` allowlist. Never bypass with `--no-verify`.
 
-Install one hook in `~/.config/git/hooks/pre-commit` and point every clone at the shared hooks directory:
+### Relationship to ForensicAgent
 
-```sh
-git config --global core.hooksPath ~/.config/git/hooks
-```
+Safety-net is the **deterministic prevention layer** (regex, runs on every commit, no AI). [ForensicAgent](../../agents/ForensicAgent.md) is the **AI-driven detection layer** (prose rules from `~/.config/forge/forensic.yaml`, runs on demand or during audits). The hook reads `safety-net`; the agent reads `forensic.yaml`. They complement each other but never share config files.
 
-The hook (POSIX, exit 1 on hit):
+After a ForensicAgent scan surfaces a new leaked pattern, add it to `~/.config/forge/safety-net` so the hook prevents recurrence.
 
-```sh
-#!/bin/sh
-set -e
-list="${HOME}/.config/git/danger-strings"
-[ -r "$list" ] || exit 0
-staged=$(git diff --cached --name-only --diff-filter=ACMR)
-[ -z "$staged" ] && exit 0
-patterns=$(grep -Ev '^\s*(#|$)' "$list" | paste -sd '|' -)
-[ -z "$patterns" ] && exit 0
-if printf '%s\n' "$staged" | xargs -I{} git show ":{}" 2>/dev/null | grep -E "$patterns"; then
-    echo "pre-commit: known-dangerous string in staged content — fix or update danger-strings list" >&2
-    exit 1
-fi
-```
-
-`grep` over `git show ":path"` (the staged blob), not the working tree, so a partial `git add -p` is checked at the actual byte content about to be committed.
-
-CI runs the same two gates as the second line of defense: a workflow step that reads the same `danger-strings` file (committed to the dotfiles repo, fetched in CI) and fails the build if the diff against the base branch contains a hit. See [SecretScan](../SecretScan/SKILL.md) for the gitleaks CI integration.
+See [INSTALL.md](INSTALL.md) for config-file setup and verification.
 
 ## Push Policy
 


### PR DESCRIPTION
## Approach

- Rename `rules/InstallMd.md` to `rules/InstallInstructions.md` for clarity
- Update `INSTALL.md` at repo root
- New `skills/VersionControl/INSTALL.md` companion with actionable setup steps
- `skills/VersionControl/SKILL.md` edits (cleanup from external session)
- `skills/SettingsMaintenance/ClaudeBaseline.md` updates
- `NAME-0001 Forge Naming Collisions` ADR documenting the ~/.config/forge/ coexistence pattern with other CLIs named "forge"

## Test plan

- [x] `forge validate` passes
- [ ] CI green