### PR TITLE
feat: safety-net hook + ForensicAgent 0.5.0 (UserConfig-driven config)

### DIFF
--- a/agents/ForensicAgent.md
+++ b/agents/ForensicAgent.md
@@ -1,7 +1,7 @@
 ---
 name: ForensicAgent
 description: "Forensic security analyst — PII detection, secret scanning, identity leak auditing across git history, staged changes, working tree, all branches, and cross-repo GitHub-wide audits. USE WHEN PII scan, leaked name, pre-publication audit, git history audit, secret scan, security review, forensic analysis, scan my github."
-version: 0.4.0
+version: 0.5.0
 ---
 
 # Forensic Agent
@@ -23,22 +23,47 @@ You are a forensic security analyst for the forge ecosystem. Your job is to dete
 
 ### Phase 1: Discovery
 
-1. **Gather PII terms**: Ask the user (or check the prompt) for known PII — real names, company names, email addresses, team member names, phone numbers, addresses. Distinguish two classes:
-   - **Current identifiers** (acceptable in attribution): the address the user publishes today, current author name.
-   - **Deprecated identifiers** (red flag): former emails, old phone numbers, retired hostnames, abandoned handles. A deprecated address in source code is a leak even if the current address sits next to it.
-2. **Load attribution allowlist**: Some PII surfaces are intentional and acceptable. The user-supplied list of acceptable surfaces typically includes:
-   - Author name in `LICENSE`, `LICENSE.*`, `COPYING`
-   - `author.name` / `author.email` in `.claude-plugin/plugin.json`, `package.json`, `pyproject.toml`, `Cargo.toml`
-   - The single published contact address in `SECURITY.md`
-   Mark these as "acceptable attribution" in the report rather than as leaks. The agent itself carries no hardcoded identities — every value is supplied by the invoker (prompt, danger-strings file, or session config).
-3. **Detect gitleaks**: Run `which gitleaks` to check availability. If present, use it for secret scanning. If absent, fall back to Grep-based pattern matching.
+1. **Load config**: Read `~/.config/forge/forensic.yaml` per the [UserConfig](../rules/UserConfig.md) rule. The schema follows the [autoMode-mirror pattern](../skills/BuildSkill/UserConfigSchema.md) — natural-language entries, the `$defaults` token to splice in built-ins, and four tiers with precedence `hard_deny` > `soft_deny` > `allow` > `environment`:
+
+    ```yaml
+    # ~/.config/forge/forensic.yaml
+    environment:
+        - "$defaults"
+        - "Owner: Alice Example, primary published address alice@example.com."
+        - "Maintained repos under github.com/alice-example."
+
+    allow:
+        - "$defaults"
+        - "Author attribution as the owner's name is acceptable in LICENSE, .claude-plugin/plugin.json author, package.json author, Cargo.toml package.authors, and SECURITY.md."
+        - "Test fixtures under tests/fixtures/, evals/baselines/, and example/ may contain inert credentials."
+
+    soft_deny:
+        - "$defaults"
+        - "Block any deprecated address at @old-domain.com."
+        - "Block the legacy username 'aliceexample' anywhere."
+
+    hard_deny:
+        - "$defaults"
+        - "Live API tokens or private keys (gitleaks layer)."
+        - "Czech personal identifiers (rodné číslo, IČO, DIČ, +420 phone) in any committed file."
+    ```
+
+    Entries are prose, not regex — the agent reads them as natural-language rules. Setting any tier without `"$defaults"` replaces the entire built-in list for that tier. The agent carries no hardcoded identities — every value comes from this file.
+
+    A sibling artifact at `~/.config/forge/safety-net` holds the deterministic regex list consumed by the safety-net hook (`hooks/safety-net.sh`). The two files are independent; the hook never reads `forensic.yaml`.
+
+2. **Gather session-specific PII**: Ask the user or check the prompt for any additional context not yet captured in the config file.
+
+3. **Detect gitleaks**: Run `which gitleaks`. If missing, install (`brew install gitleaks`) before continuing — gitleaks is mandatory for any reachable local clone. Do not partially scan.
+
 4. **Determine mode** from prompt context:
    - **On-demand (single repo)**: Full scan — git history + working tree + all branches + submodules. Triggered by explicit user request on one repository.
    - **On-demand (cross-repo)**: Enumerate every repo owned by an account and scan each. Triggered by "scan my github", "audit my public domain", "PII sweep". See *Cross-repo audit* below.
    - **Pre-publication**: Staged changes + recent commits since last push. Triggered before push/PR.
    - **Council specialist**: Targeted scan of specific files or commits. Triggered by delegation from council lead.
    - **Continuous**: Uncommitted changes + staged files only (fast). Triggered by hook or session start.
-5. **Set scan scope** based on mode. For on-demand, scan everything **including non-default branches and dangling refs**. For pre-publication, limit to `git diff --cached` and `git log @{push}..HEAD`. For continuous, scan working tree only.
+
+5. **Set scan scope** based on mode. For on-demand, scan everything **including non-default branches, tags, and remote refs**. For pre-publication, limit to `git diff --cached` and `git log @{push}..HEAD`. For continuous, scan working tree only.
 
 ### Cross-repo audit (GitHub-wide)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -28,6 +28,15 @@
                         "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/adr-context.sh"
                     }
                 ]
+            },
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/safety-net.sh"
+                    }
+                ]
             }
         ]
     }

--- a/hooks/safety-net.sh
+++ b/hooks/safety-net.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# hooks/safety-net.sh
+#
+# Claude Code PreToolUse hook for Bash. Inspects `git commit` invocations and
+# blocks the call when any staged blob matches a pattern from
+# ~/.config/forge/safety-net.
+#
+# `safety-net` is the user's list of anything that must never enter a
+# repo — current and deprecated identifiers, internal hostnames, personal
+# phones, vendor names, anything you can describe as a regex. One extended
+# regex per line, `#` comments allowed.
+#
+# Auto-discovered via hooks.json when forge-core is installed as a Claude Code
+# plugin. No manual settings.json wiring needed.
+#
+# Override the config path via FORGE_SAFETY_NET.
+#
+# Exits 0 always per the HookScripts rule. Communicates via JSON on stdout.
+
+input=$(cat 2>/dev/null || true)
+
+# Heuristic: act only when the tool input contains a git commit command
+case "$input" in
+    *'"command"'*'git commit'*) ;;
+    *) exit 0 ;;
+esac
+
+config="${FORGE_SAFETY_NET:-${HOME}/.config/forge/safety-net}"
+[ -r "$config" ] || exit 0
+
+patterns=$(grep -Ev '^[[:space:]]*(#|$)' "$config" 2>/dev/null | paste -sd '|' - 2>/dev/null)
+[ -z "$patterns" ] && exit 0
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
+[ -z "$staged" ] && exit 0
+
+hit_count=$(
+    printf '%s\n' "$staged" \
+        | xargs -I{} git show ":{}" 2>/dev/null \
+        | grep -cE "$patterns" 2>/dev/null \
+        || printf '0'
+)
+
+if [ -n "$hit_count" ] && [ "$hit_count" -gt 0 ]; then
+    if command -v jq >/dev/null 2>&1; then
+        jq -nc \
+            --arg msg "safety-net: ${hit_count} danger-string hit(s) in staged content. Unstage the offending lines or update ${config}." \
+            '{decision: "block", reason: $msg}'
+    else
+        printf '{"decision":"block","reason":"safety-net: %s danger-string hit(s) in staged content. Unstage the offending lines or update %s."}\n' "$hit_count" "$config"
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Problem

No pre-commit content gate exists at the Claude Code hook layer. ForensicAgent also lacked structured config for its scan parameters, relying on prompt-supplied values that vary per invocation.

## Approach

**safety-net.sh** — PreToolUse hook on Bash matcher, fires only on `git commit`. Reads user-curated regex list from `~/.config/forge/safety-net`, greps staged blobs, emits `{"decision":"block"}` on hit. Complementary to [claude-code-safety-net](https://github.com/kenryu42/claude-code-safety-net) (destructive-command blocker).

**ForensicAgent 0.5.0** — reads `~/.config/forge/forensic.yaml` per the UserConfig rule. Adopts the autoMode-mirror pattern with four-tier precedence (`hard_deny` > `soft_deny` > `allow` > `environment`). The environment tier carries identity context (owner name, published address, maintained repos); the deny tiers carry deprecated identifiers and known-bad patterns.

## Test plan

- [x] Hook blocks staged danger-string matches, passes clean commits and non-commit commands
- [x] `forge validate` passes
- [ ] CI green