### PR TITLE
docs: add DataWorkingLayer rule and fix UseForge skill-asset guidance

### DIFF
--- a/rules/DataWorkingLayer.md
+++ b/rules/DataWorkingLayer.md
@@ -1,0 +1,9 @@
+Source documents live in `~/Documents`. Their extracted, machine-readable form is the working layer under `~/Data/<Type>/<project>/`, mirroring the source tree. The vault references that layer through a note's `paths:` pointer and never copies the working file's body into a note.
+
+Three layers, one direction:
+
+- `~/Documents`: original binaries (docx, pdf, xlsx), untouched.
+- `~/Data/<Type>/<project>/`: extracted text plus per-project build material (scripts, fonts, images). Lossless, canonical, regenerable.
+- vault: curated notes that point at the Data layer and carry the schema (frontmatter, summary, wikilinks).
+
+Keep file stems identical across `~/Documents` and `~/Data` so a note's pointer and its source stay paired. Per-project build scripts and assets are working material: they live in the project's Data area, never in the vault and never in forge. Forge carries the method; each project's content is data.

--- a/rules/UseForge.md
+++ b/rules/UseForge.md
@@ -1,6 +1,6 @@
 Forge assembles and deploys module content to AI provider directories. Key behaviors to know:
 
-Assembly deploys only `.md` files. Non-markdown files (Python scripts, shell scripts, YAML sidecars) in skill directories are silently dropped. Ship executables in `bin/` at the plugin root instead.
+A skill directory deploys its whole tree: `SKILL.md` is assembled (frontmatter stripped, provider transforms applied), and every other file is copied verbatim with its extension and subdirectory structure preserved. Ship a text helper inside the skill and call it at runtime via `${CLAUDE_SKILL_DIR}/...`. Non-UTF-8 binary files are skipped with a warning, and the executable bit is not preserved yet, so invoke a deployed script through its interpreter (`uv run helper`), not as a bare `./helper`. Compiled binaries still belong in `bin/` at the plugin root.
 
 `forge install` deploys rules, skills, and agents, not hooks. Wire hooks manually into `~/.claude/settings.json` using absolute paths. Read the module's `hooks/hooks.json` for the full hook list and replace `${CLAUDE_PLUGIN_ROOT}` with the absolute path to your clone.
 


### PR DESCRIPTION
## Problem

`UseForge` still says assembly only deploys `.md` files and tells you to put skill helpers in `bin/`. ASSEMBLY-0012 in forge-cli changed that: a skill directory deploys its whole tree, only the top-level `SKILL.md` is assembled, everything else is copied verbatim. The rule now points the wrong way, and a helper parked in `bin/` to satisfy it misses the `${CLAUDE_SKILL_DIR}` pattern that works now.

`DataWorkingLayer` never existed. MarkdownExtract (forge-text) and BuildDeck (forge-docs) both name the `~/Documents`, `~/Data`, vault convention, but no rule defined it, so the references dangled.

## Fix

Add `rules/DataWorkingLayer.md`: originals stay in `~/Documents`, the extracted working layer lives in `~/Data/<Type>/<project>/`, and the vault references that layer instead of copying it.

Rewrite the `UseForge` assembly paragraph for verbatim deploy. Non-UTF-8 binaries are skipped with a warning, the executable bit isn't preserved yet so a deployed helper runs through its interpreter, and compiled binaries still belong in `bin/`.

## Out of scope

My working copy also has a `--force` paragraph edit to UseForge from separate work. It's left out. This branch resets UseForge to main first, then changes only the assembly line.

## Test plan

- [x] Built forge-cli and ran `forge install` on a skill bundling a UTF-8 `uv run` helper. It deployed (as `644`, so the exec-bit caveat holds).
- [x] `jj diff` shows only the two rule files.
- [ ] CI: gitleaks, semgrep, `forge validate`.
